### PR TITLE
feat(studio): add harmony studio desktop workflow UI

### DIFF
--- a/.harmony/START.md
+++ b/.harmony/START.md
@@ -138,6 +138,18 @@ Within these namespaces, common subpaths are:
 9. **Begin** highest-priority unblocked task
 10. **Before finishing:** Complete `quality/session-exit.md`, verify against `quality/complete.md`
 
+## Runtime Quick Start
+
+From repo root:
+
+```bash
+.harmony/runtime/run --help
+.harmony/runtime/run studio
+```
+
+Use `studio` when you want a visual workflow graph + inspector + safe staged
+edit/apply flow.
+
 ## Assistants
 
 Assistants are focused specialists available via `@mention`:

--- a/.harmony/capabilities/commands/manifest.yml
+++ b/.harmony/capabilities/commands/manifest.yml
@@ -20,6 +20,13 @@ commands:
     access: human
     argument_hint: "[@project-root] [--force] [--no-claude-alias] [--with-boot-files] [--with-agent-platform-adapters] [--agent-platform-adapters <csv>]"
 
+  - id: studio
+    display_name: Launch Studio
+    path: studio.md
+    summary: Launch Harmony Studio for workflow graph design, inspection, and safe staged edits.
+    access: human
+    argument_hint: "[--root <project-root>]"
+
   - id: recover
     display_name: Recover from Errors
     path: recover.md

--- a/.harmony/capabilities/commands/studio.md
+++ b/.harmony/capabilities/commands/studio.md
@@ -1,0 +1,51 @@
+---
+title: Launch Studio
+description: Launch Harmony Studio for workflow graph design, inspection, and safe staged edits.
+access: human
+argument-hint: "[--root <project-root>]"
+---
+
+# Launch Studio `/studio`
+
+Open the Harmony Studio desktop app from a project containing `.harmony/`.
+
+## Usage
+
+```text
+/studio
+/studio --root @/path/to/project-root
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `--root` | No | Project root containing `.harmony/`. Defaults to current working directory. |
+
+## Implementation
+
+From project root:
+
+```bash
+.harmony/runtime/run studio
+```
+
+or, from inside `.harmony/`:
+
+```bash
+./runtime/run studio
+```
+
+When `studio` is invoked, the launcher uses source mode to avoid stale prebuilt binary drift.
+
+## Output
+
+- Opens the `harmony_studio` desktop window
+- Loads workflows from `.harmony/orchestration/workflows/`
+- Enables graph inspection, staged edit buffer, patch preview export, and apply audit browsing
+
+## References
+
+- **Runtime launcher:** `.harmony/runtime/run`
+- **Kernel studio command:** `.harmony/runtime/crates/kernel/src/main.rs`
+- **Studio crate:** `.harmony/runtime/crates/studio/`

--- a/.harmony/catalog.md
+++ b/.harmony/catalog.md
@@ -95,6 +95,7 @@ Atomic operations in `capabilities/commands/`:
 | Command | Access | Description |
 |---------|--------|-------------|
 | [init.md](./capabilities/commands/init.md) | human | Initialize project-level bootstrap files (`AGENTS.md`, `CLAUDE.md` alias, optional `BOOT*.md`) |
+| [studio.md](./capabilities/commands/studio.md) | human | Launch Harmony Studio for workflow graph design, inspection, and safe staged edits |
 | [recover.md](./capabilities/commands/recover.md) | human | Recovery procedures for common agent failure modes |
 | [validate-frontmatter.md](./capabilities/commands/validate-frontmatter.md) | human | Validate YAML frontmatter in markdown files |
 | [create-workflow.md](./capabilities/commands/create-workflow.md) | human | Scaffold a new workflow with gap-aware structure |

--- a/.harmony/runtime/README.md
+++ b/.harmony/runtime/README.md
@@ -38,3 +38,24 @@ harmony studio
 
 When invoked as `studio`, the launcher forces source mode so the command works
 even if bundled prebuilt kernel binaries are older than the workspace code.
+
+## Studio Scope
+
+`harmony_studio` provides:
+
+- workflow index and validation visibility
+- dependency graph canvas (pan/zoom/select)
+- workflow detail inspector from parsed `WORKFLOW.md` frontmatter
+- staged edit buffer with patch preview export
+- guarded apply with rollback and apply audit artifacts
+
+## Studio Artifacts
+
+Studio writes reports under:
+
+- `.harmony/output/reports/*-studio-patch-preview.diff`
+- `.harmony/output/reports/*-studio-apply-audit.md`
+
+Operational build state uses runtime-local storage:
+
+- `.harmony/runtime/_ops/state/build/runtime-crates-target/`

--- a/.harmony/runtime/README.md
+++ b/.harmony/runtime/README.md
@@ -21,3 +21,20 @@ Executable runtime layer for harness-native service invocation.
 - Keep runtime structural assets under `config/`, `crates/`, `spec/`, and `wit/`.
 - Keep mutable operational data under `_ops/state/`.
 - Keep audit/verification documents under `_meta/evidence/`.
+
+## Studio Launch
+
+Use the runtime CLI to open the desktop workflow studio:
+
+```bash
+.harmony/runtime/run studio
+```
+
+or, if `harmony` is already on PATH:
+
+```bash
+harmony studio
+```
+
+When invoked as `studio`, the launcher forces source mode so the command works
+even if bundled prebuilt kernel binaries are older than the workspace code.

--- a/.harmony/runtime/_meta/evidence/verification-scenarios.md
+++ b/.harmony/runtime/_meta/evidence/verification-scenarios.md
@@ -128,3 +128,25 @@ Expected:
 
 - Response for `c1` acknowledging cancellation (implementation choice).
 - Final response for `long` with `error.code = "CANCELLED"`.
+
+## 10) Studio command discoverability and help
+
+Command:
+
+```bash
+.harmony/runtime/run --help
+```
+
+Expected:
+
+- command list includes `studio`
+
+Then:
+
+```bash
+.harmony/runtime/run studio --help
+```
+
+Expected:
+
+- help includes `Launch Harmony Studio desktop UI`

--- a/.harmony/runtime/crates/Cargo.lock
+++ b/.harmony/runtime/crates/Cargo.lock
@@ -3,6 +3,111 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
+name = "accesskit"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eca13c82f9a5cd813120b2e9b6a5d10532c6e4cd140c295cebd1f770095c8a5"
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb9cc46b7fb6987c4f891f0301b230b29d9e69b4854f060a0cf41fbc407ab77"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d880a613f29621c90e801feec40f5dd61d837d7e20bf9b67676d45e7364a36"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0ddfc3fe3d457d11cc1c4989105986a03583a1d54d0c25053118944b62e100"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d552169ef018149966ed139bb0311c6947b3343e9140d1b9f88d69da9528fd"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d277279d0a3b0c0021dd110b55aa1fe326b09ee2cbc338df28f847c7daf94e25"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db08dff285306264a1de127ea07bb9e7a1ed71bd8593c168d0731caa782516c9"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +115,12 @@ checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -35,6 +146,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,12 +176,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
+name = "android-activity"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+dependencies = [
+ "android-properties",
+ "bitflags 2.11.0",
+ "cc",
+ "cesu8",
+ "jni",
+ "jni-sys",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e4850548ff4a25a77ce3bda7241874e17fb702ea551f0cc62a2dbe052f1272"
+dependencies = [
+ "anstyle",
+ "unicode-width",
 ]
 
 [[package]]
@@ -127,11 +293,224 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.3",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.3",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.3",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "auto_enums"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c170965892137a3a9aeb000b4524aa3cc022a310e709d848b6e1cdce4ab4781"
+dependencies = [
+ "derive_utils",
  "proc-macro2",
  "quote",
  "syn",
@@ -144,10 +523,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
+]
 
 [[package]]
 name = "bit-set"
@@ -165,6 +623,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +639,18 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
 
 [[package]]
 name = "block-buffer"
@@ -186,6 +662,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,10 +717,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -207,10 +755,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.11.0",
+ "polling",
+ "rustix 1.1.3",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.3",
+ "wayland-backend",
+ "wayland-client",
+]
 
 [[package]]
 name = "cap-fs-ext"
@@ -220,7 +825,7 @@ checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "windows-sys 0.59.0",
 ]
 
@@ -245,7 +850,7 @@ dependencies = [
  "ambient-authority",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "ipnet",
  "maybe-owned",
  "rustix 1.1.3",
@@ -261,7 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -272,7 +877,7 @@ checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix 1.1.3",
 ]
 
@@ -303,10 +908,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -349,6 +1008,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "clru"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,10 +1032,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-field-offset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fcde4ca1211b5a94b573083c472ee19e86b19a441913f66e1cc5c41daf0255"
+dependencies = [
+ "const-field-offset-macro",
+ "field-offset",
+]
+
+[[package]]
+name = "const-field-offset-macro"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5387f5bbc9e9e6c96436ea125afa12614cebf8ac67f49abc08c1e7a891466c90"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "copypasta"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6811e17f81fe246ef2bc553f76b6ee6ab41a694845df1d37e52a92b7bbd38a"
+dependencies = [
+ "clipboard-win",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "smithay-clipboard",
+ "x11-clipboard",
+]
 
 [[package]]
 name = "core-foundation"
@@ -380,12 +1123,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
+name = "cpp"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bcac3d8234c1fb813358e83d1bb6b0290a3d2b3b5efc6b88bfeaf9d8eec17"
+dependencies = [
+ "cpp_macros",
+]
+
+[[package]]
+name = "cpp_build"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f8638c97fbd79cc6fc80b616e0e74b49bac21014faed590bbc89b7e2676c90"
+dependencies = [
+ "cc",
+ "cpp_common",
+ "lazy_static",
+ "proc-macro2",
+ "regex",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "cpp_common"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fcfea2ee05889597d35e986c2ad0169694320ae5cc8f6d2640a4bb8a884560"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cpp_macros"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d156158fe86e274820f5a53bc9edb0885a6e7113909497aa8d883b69dd171871"
+dependencies = [
+ "aho-corasick",
+ "byteorder",
+ "cpp_common",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -434,7 +1275,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -514,6 +1355,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +1395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +1409,24 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "ctor-lite"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "debugid"
@@ -564,6 +1444,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfae181bab5ab6c5478b2ccb69e4c68a02f8c3ec72f6616bfec9dbc599d2ee0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -618,6 +1532,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +1556,67 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "drm"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "drm-ffi",
+ "drm-fourcc",
+ "libc",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e41459d99a9b529845f6d2c909eb9adf3b6d2f82635ae40be8de0601726e8b"
+dependencies = [
+ "drm-sys",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-fourcc"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
+name = "drm-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafb66c8dbc944d69e15cfcc661df7e703beffbaec8bd63151368b06c5f9858c"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.6.5",
 ]
 
 [[package]]
@@ -656,6 +1647,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +1707,57 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "euclid"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -688,6 +1777,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fd-lock"
 version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,10 +1814,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "femtovg"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a125295d4de2b2473e731c4612599ba3cdf7e05af6bba16f324ba8ffbf093436"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "fnv",
+ "glow",
+ "image",
+ "imgref",
+ "itertools 0.14.0",
+ "log",
+ "rgb",
+ "slotmap",
+ "ttf-parser 0.25.1",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "fnv"
@@ -715,6 +1897,94 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "log",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "fontdue"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
+dependencies = [
+ "hashbrown 0.15.5",
+ "rayon",
+ "ttf-parser 0.21.1",
+]
+
+[[package]]
+name = "fontique"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bbc252c93499b6d3635d692f892a637db0dbb130ce9b32bf20b28e0dcc470b"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "icu_locale_core",
+ "linebender_resource_handle",
+ "memmap2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "read-fonts",
+ "roxmltree",
+ "smallvec",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -741,7 +2011,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix 1.1.3",
  "windows-sys 0.59.0",
 ]
@@ -754,6 +2024,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -777,10 +2048,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -800,8 +2106,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -833,6 +2141,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gbm"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
+dependencies = [
+ "bitflags 2.11.0",
+ "drm",
+ "drm-fourcc",
+ "gbm-sys",
+ "libc",
+]
+
+[[package]]
+name = "gbm-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13a5f2acc785d8fb6bf6b7ab6bfb0ef5dad4f4d97e8e70bb8e470722312f76f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +2170,25 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.3",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -881,6 +2230,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,10 +2251,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg_aliases",
+ "cgl",
+ "dispatch2",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "raw-window-handle",
+ "wayland-sys",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+dependencies = [
+ "cfg_aliases",
+ "glutin",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
 
 [[package]]
 name = "h2"
@@ -914,6 +2362,30 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -953,6 +2425,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmony_studio"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_yaml",
+ "slint",
+ "slint-build",
+ "walkdir",
+]
+
+[[package]]
 name = "harmony_wasm_host"
 version = "0.1.0"
 dependencies = [
@@ -984,7 +2468,10 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+ "rayon",
  "serde",
 ]
 
@@ -993,6 +2480,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1001,10 +2493,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "htmlparser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ce8546b993eaf241d69ded33b1be6d205dd9857ec879d9d18bd05d3676e144"
 
 [[package]]
 name = "http"
@@ -1065,6 +2575,286 @@ dependencies = [
 ]
 
 [[package]]
+name = "i-slint-backend-linuxkms"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b8827952ecfbbf76c8cb5bc3388ca9124c34f2b4fe5dffcfe57800d2a484885"
+dependencies = [
+ "bytemuck",
+ "calloop 0.14.4",
+ "drm",
+ "gbm",
+ "glutin",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-renderer-femtovg",
+ "i-slint-renderer-software",
+ "input",
+ "memmap2",
+ "nix",
+ "raw-window-handle",
+ "xkbcommon",
+]
+
+[[package]]
+name = "i-slint-backend-qt"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9d5db3221f453439ec5ad9b6ac3bb8d2b4825b2f8734f0cde4b67d7336c3da"
+dependencies = [
+ "const-field-offset",
+ "cpp",
+ "cpp_build",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "lyon_path",
+ "pin-project",
+ "pin-weak",
+ "qttypes",
+ "vtable",
+]
+
+[[package]]
+name = "i-slint-backend-selector"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5a7e591a7257096e1f3da1bbb9ad6a140c307d0eee74f008a0b412fdb20dec"
+dependencies = [
+ "cfg-if",
+ "i-slint-backend-linuxkms",
+ "i-slint-backend-qt",
+ "i-slint-backend-winit",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "i-slint-renderer-femtovg",
+]
+
+[[package]]
+name = "i-slint-backend-winit"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbf4789191740f939c9563b8850379122d7b5c1ceb09f9297b50ad53e408787"
+dependencies = [
+ "accesskit",
+ "accesskit_winit",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "copypasta",
+ "derive_more",
+ "futures",
+ "glutin",
+ "glutin-winit",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "i-slint-renderer-femtovg",
+ "i-slint-renderer-skia",
+ "i-slint-renderer-software",
+ "imgref",
+ "lyon_path",
+ "muda",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "pin-weak",
+ "raw-window-handle",
+ "rgb",
+ "scoped-tls-hkt",
+ "scopeguard",
+ "softbuffer",
+ "strum",
+ "vtable",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.62.2",
+ "winit",
+ "zbus",
+]
+
+[[package]]
+name = "i-slint-common"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7659797fd28d4df3ed275ff95bf730bdf4a88d253f07e1ee8d0032d70138c3a"
+dependencies = [
+ "fontique",
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "i-slint-compiler"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a6f358d0d5389869d67cd6ab6f5acf98fe31827264a696593e9687213cff682"
+dependencies = [
+ "annotate-snippets",
+ "by_address",
+ "derive_more",
+ "fontdue",
+ "i-slint-common",
+ "image",
+ "itertools 0.14.0",
+ "linked_hash_set",
+ "lyon_extra",
+ "lyon_path",
+ "num_enum",
+ "proc-macro2",
+ "quote",
+ "rayon",
+ "resvg",
+ "rowan",
+ "rspolib",
+ "smol_str 0.3.5",
+ "strum",
+ "typed-index-collections",
+ "url",
+]
+
+[[package]]
+name = "i-slint-core"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a95591ff85f8e2ff11c8d26ea8429768c2b77866e0c7e7fd49348f23ad108b5c"
+dependencies = [
+ "auto_enums",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "chrono",
+ "clru",
+ "const-field-offset",
+ "derive_more",
+ "euclid",
+ "htmlparser",
+ "i-slint-common",
+ "i-slint-core-macros",
+ "image",
+ "lyon_algorithms",
+ "lyon_extra",
+ "lyon_geom",
+ "lyon_path",
+ "num-traits",
+ "once_cell",
+ "parley",
+ "pin-project",
+ "pin-weak",
+ "portable-atomic",
+ "pulldown-cmark",
+ "raw-window-handle",
+ "resvg",
+ "rgb",
+ "scoped-tls-hkt",
+ "scopeguard",
+ "skrifa",
+ "slab",
+ "strum",
+ "sys-locale",
+ "thiserror 2.0.18",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
+ "vtable",
+ "wasm-bindgen",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
+name = "i-slint-core-macros"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc5f2f71682787dd5c6299555c0de635009eb269bbc54d6198e0d225b69fae4"
+dependencies = [
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "i-slint-renderer-femtovg"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6eccda447999bc6222988500b841b64c953988986af182334e7ba9a30f0edd"
+dependencies = [
+ "cfg-if",
+ "const-field-offset",
+ "derive_more",
+ "femtovg",
+ "glow",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "imgref",
+ "lyon_path",
+ "pin-weak",
+ "rgb",
+ "ttf-parser 0.25.1",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "i-slint-renderer-skia"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64546232c0370f291e65fc92a4f4fc777ea78d5f48467873cb968b1de52e9ab"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "const-field-offset",
+ "derive_more",
+ "glow",
+ "glutin",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "lyon_path",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "pin-weak",
+ "raw-window-handle",
+ "raw-window-metal",
+ "read-fonts",
+ "scoped-tls-hkt",
+ "skia-safe",
+ "softbuffer",
+ "unicode-segmentation",
+ "vtable",
+ "windows 0.62.2",
+ "write-fonts",
+]
+
+[[package]]
+name = "i-slint-renderer-software"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a59be6c34935c4f8e41aa67a63518d5c59219c8eeb1d07af420bed8334fa31d7"
+dependencies = [
+ "bytemuck",
+ "clru",
+ "derive_more",
+ "euclid",
+ "fontdue",
+ "i-slint-common",
+ "i-slint-core",
+ "integer-sqrt",
+ "lyon_path",
+ "num-traits",
+ "skrifa",
+ "zeno",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +2866,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1109,6 +2899,7 @@ checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -1197,6 +2988,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.12",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,13 +3046,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "input"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
+dependencies = [
+ "bitflags 2.11.0",
+ "input-sys",
+ "libc",
+ "log",
+ "udev",
+]
+
+[[package]]
+name = "input-sys"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "io-extras"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1242,7 +3129,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -1250,6 +3137,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1281,6 +3177,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,7 +3226,7 @@ checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
  "ahash",
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bytecount",
  "clap",
  "fancy-regex",
@@ -1331,6 +3249,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags 2.11.0",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,10 +3306,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "libm"
@@ -1368,6 +3351,38 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
+ "redox_syscall 0.7.1",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1375,6 +3390,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1404,6 +3425,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c0829e28c4f336396f250d850c3987e16ce6db057ffe047ce0dd54aab6b647"
+dependencies = [
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_extra"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca94c7bf1e2557c2798989c43416822c12fc5dcc5e17cc3307ef0e71894a955"
+dependencies = [
+ "lyon_path",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e260b6de923e6e47adfedf6243013a7a874684165a6a277594ee3906021b2343"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aeca86bcfd632a15984ba029b539ffb811e0a70bf55e814ef8b0f54f506fdeb"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +3488,16 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "memchr"
@@ -1434,10 +3515,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1451,6 +3566,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "muda"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "keyboard-types",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "png 0.17.16",
+ "thiserror 2.0.18",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +3666,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "num"
@@ -1505,6 +3719,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +3767,404 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.3",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1570,12 +4193,51 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "orbclient"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ad2c6bae700b7aa5d1cc30c59bdd3a1c180b09dbaea51e2ae2b8e1cf211fdd"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1595,9 +4257,23 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parley"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada5338c3a9794af7342e6f765b6e78740db37378aced034d7bf72c96b94ed94"
+dependencies = [
+ "fontique",
+ "harfrust",
+ "hashbrown 0.16.1",
+ "linebender_resource_handle",
+ "skrifa",
+ "swash",
 ]
 
 [[package]]
@@ -1607,10 +4283,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1625,10 +4333,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pin-weak"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b330c9d1b92dfe68442ca20b009c717d5f0b1e3cf4965e62f704c3c6e95a1305"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+dependencies = [
+ "critical-section",
+]
 
 [[package]]
 name = "postcard"
@@ -1677,12 +4451,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.10+spec-1.0.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1696,6 +4498,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags 2.11.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "pulley-interpreter"
 version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,6 +4526,51 @@ dependencies = [
  "log",
  "sptr",
  "wasmtime-math",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "qttypes"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7edf5b38c97ad8900ad2a8418ee44b4adceaa866a4a3405e2f1c909871d7ebd"
+dependencies = [
+ "cpp",
+ "cpp_build",
+ "semver",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1729,8 +4595,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1740,7 +4616,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1750,6 +4636,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -1773,10 +4736,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
+dependencies = [
+ "bytemuck",
+ "core_maths",
+ "font-types",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -1802,7 +4794,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.5",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "smallvec",
 ]
 
@@ -1841,7 +4833,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1872,6 +4864,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b563218631706d614e23059436526d005b50ab5f2d506b55a17eb65c5eb83419"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg 0.5.12",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "rspolib"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fda9a7796aff63a7b1b39ccc93fffaaf65e20042984b4843041a49ca4677535"
+dependencies = [
+ "lazy_static",
+ "natord",
+ "snafu",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,9 +4931,24 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1926,6 +4993,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser 0.25.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,10 +5026,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scoped-tls-hkt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9603871ffe5df3ac39cb624790c296dbd47a400d202f56bf3e414045099524d"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit 0.19.2",
+ "tiny-skia",
+]
 
 [[package]]
 name = "semver"
@@ -2000,12 +5110,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2060,10 +5190,144 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "skia-bindings"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6f96e00735f14a781aac8a6870c862b8cc831df6d8e4ad77ab78e11411b9af"
+dependencies = [
+ "bindgen",
+ "cc",
+ "flate2",
+ "heck",
+ "pkg-config",
+ "regex",
+ "serde_json",
+ "tar",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "skia-safe"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a71c01d325d40b1031dee67d251a5e0132e79e2a9ec272149a4f4a0d4b8b3be"
+dependencies = [
+ "bitflags 2.11.0",
+ "skia-bindings",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slint"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25b87d458205e79efb30545cae083aec2ccb1b192c46a55ae6d54403cdacb33"
+dependencies = [
+ "const-field-offset",
+ "i-slint-backend-qt",
+ "i-slint-backend-selector",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "i-slint-renderer-femtovg",
+ "i-slint-renderer-software",
+ "num-traits",
+ "once_cell",
+ "pin-weak",
+ "slint-macros",
+ "unicode-segmentation",
+ "vtable",
+]
+
+[[package]]
+name = "slint-build"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064ef470cc8ab046319db94d0727f080fbd05322d07d774eb6de607d97defb8d"
+dependencies = [
+ "derive_more",
+ "fontique",
+ "i-slint-compiler",
+ "spin_on",
+ "toml_edit 0.24.1+spec-1.1.0",
+]
+
+[[package]]
+name = "slint-macros"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ecc09bbc42c780d5b7ed7d41f7573dfd67343e11cdac27c07b88a8f933958e6"
+dependencies = [
+ "i-slint-compiler",
+ "proc-macro2",
+ "quote",
+ "spin_on",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -2072,6 +5336,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.0",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.11.0",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.3",
+ "thiserror 2.0.18",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.20.0",
+ "wayland-backend",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f7a918bd2a9951d18ee6e48f076843e8e73a9a5d22cf05bcd4b7a81bdd04e17"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2095,12 +5462,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "softbuffer"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
+dependencies = [
+ "as-raw-xcb-connection",
+ "bytemuck",
+ "fastrand",
+ "js-sys",
+ "memmap2",
+ "ndk",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "raw-window-handle",
+ "redox_syscall 0.5.18",
+ "rustix 1.1.3",
+ "tiny-xlib",
+ "tracing",
+ "wasm-bindgen",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-sys",
+ "web-sys",
+ "windows-sys 0.61.2",
+ "x11rb",
+]
+
+[[package]]
 name = "spdx"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "spin_on"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076e103ed41b9864aa838287efe5f4e3a7a0362dd00671ae62a212e5e4612da2"
+dependencies = [
+ "pin-utils",
 ]
 
 [[package]]
@@ -2116,10 +5523,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo 0.13.0",
+ "siphasher",
+]
+
+[[package]]
+name = "swash"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
+dependencies = [
+ "skrifa",
+ "yazi",
+ "zeno",
+]
 
 [[package]]
 name = "syn"
@@ -2147,6 +5611,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "js-sys",
+ "libc",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2180,10 +5656,21 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix 0.38.44",
  "windows-sys 0.59.0",
  "winx",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2193,6 +5680,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,6 +5700,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -2242,6 +5748,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,14 +5793,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-xlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+dependencies = [
+ "as-raw-xcb-connection",
+ "ctor-lite",
+ "libloading",
+ "pkg-config",
+ "tracing",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2316,9 +5891,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -2331,6 +5921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,9 +5937,43 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.24.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.8+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
+dependencies = [
  "winnow",
 ]
 
@@ -2349,6 +5982,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower-service"
@@ -2362,6 +6001,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2405,16 +6045,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "typed-index-collections"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898160f1dfd383b4e92e17f0512a7d62f3c51c44937b23b6ffc3a1614a8eaccd"
+dependencies = [
+ "bincode",
+ "serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "udev"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
+dependencies = [
+ "io-lifetimes 1.0.11",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -2435,6 +6177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +6192,33 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo 0.13.0",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -2466,6 +6241,18 @@ checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -2474,6 +6261,29 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753be81c38dff787d177b5939af1fa16f72f0d0d21a6b7d74ae56e29cd26f2a6"
+dependencies = [
+ "const-field-offset",
+ "portable-atomic",
+ "stable_deref_trait",
+ "vtable-macro",
+]
+
+[[package]]
+name = "vtable-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfcf6171aa2b0f85718ca5888ca32f6edf61d1849f8e4b3786ad890e5b68f68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "walkdir"
@@ -2778,7 +6588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1161c8f62880deea07358bc40cceddc019f1c81d46007bc390710b2fe24ffc"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "directories-next",
  "log",
  "postcard",
@@ -2786,7 +6596,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml",
+ "toml 0.8.23",
  "windows-sys 0.59.0",
  "zstd",
 ]
@@ -2826,7 +6636,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "object 0.36.7",
  "smallvec",
@@ -2946,7 +6756,7 @@ dependencies = [
  "fs-set-times",
  "futures",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix 0.38.44",
  "system-interface",
  "thiserror 1.0.69",
@@ -3020,6 +6830,141 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.3",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix 1.1.3",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5864c4b5b6064b06b1e8b74ead4a98a6c45a285fe7a0e784d24735f011fdb078"
+dependencies = [
+ "rustix 1.1.3",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791c58fdeec5406aa37169dd815327d1e47f334219b523444bc26d70ceb4c34e"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa98634619300a535a9a97f338aed9a5ff1e01a461943e8346ff4ae26007306b"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,6 +6973,22 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wiggle"
@@ -3121,16 +7082,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3138,6 +7211,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3157,9 +7241,53 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -3167,7 +7295,26 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3176,7 +7323,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3221,7 +7377,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3261,7 +7432,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3271,6 +7442,30 @@ dependencies = [
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3292,6 +7487,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -3307,6 +7508,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3340,6 +7547,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -3355,6 +7568,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3376,6 +7595,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3394,6 +7619,12 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -3409,6 +7640,58 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winit"
+version = "0.30.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit 0.19.2",
+ "smol_str 0.2.2",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
 
 [[package]]
 name = "winnow"
@@ -3653,10 +7936,146 @@ dependencies = [
 ]
 
 [[package]]
+name = "write-fonts"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
+dependencies = [
+ "font-types",
+ "indexmap",
+ "kurbo 0.12.0",
+ "log",
+ "read-fonts",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x11-clipboard"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
+dependencies = [
+ "libc",
+ "x11rb",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.1.3",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.3",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkbcommon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a974f48060a14e95705c01f24ad9c3345022f4d97441b8a36beb7ed5c4a02d"
+dependencies = [
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.11.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yazi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "yoke"
@@ -3680,6 +8099,109 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zbus"
+version = "5.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.3",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441a0064125265655bccc3a6af6bef56814d9277ac83fce48b1cd7e160b80eac"
+dependencies = [
+ "quick-xml",
+ "serde",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zeno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
@@ -3739,6 +8261,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -3787,4 +8310,83 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+dependencies = [
+ "zune-core 0.5.1",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
 ]

--- a/.harmony/runtime/crates/Cargo.toml
+++ b/.harmony/runtime/crates/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "core",
   "wasm_host",
   "kernel",
+  "studio",
 ]
 
 [workspace.package]

--- a/.harmony/runtime/crates/kernel/src/main.rs
+++ b/.harmony/runtime/crates/kernel/src/main.rs
@@ -7,12 +7,17 @@ use harmony_core::errors::{ErrorCode, KernelError};
 use harmony_core::tiers::validate_runtime_discovery_tiers;
 use harmony_core::trace::TraceWriter;
 use harmony_wasm_host::policy::GrantSet;
+use std::process::Command as ProcessCommand;
 use std::sync::Arc;
 
 use crate::context::KernelContext;
 
 #[derive(Parser)]
-#[command(name = "harmony", version, about = "Harmony executable runtime layer (v1)")]
+#[command(
+    name = "harmony",
+    version,
+    about = "Harmony executable runtime layer (v1)"
+)]
 struct Cli {
     #[command(subcommand)]
     cmd: Command,
@@ -45,6 +50,9 @@ enum Command {
 
     /// Run the NDJSON stdio server.
     ServeStdio,
+
+    /// Launch Harmony Studio desktop UI.
+    Studio,
 
     /// Guest service scaffolding.
     Service {
@@ -82,6 +90,7 @@ fn main() -> anyhow::Result<()> {
         Command::Tool { service, op, json } => cmd_tool(&service, &op, json.as_deref()),
         Command::Validate => cmd_validate(),
         Command::ServeStdio => cmd_serve_stdio(),
+        Command::Studio => cmd_studio(),
         Command::Service { cmd } => cmd_service(cmd),
     }
 }
@@ -147,8 +156,9 @@ fn cmd_tool(service_id_or_name: &str, op: &str, input_json: Option<&str>) -> any
     let grants = GrantSet::new(caps);
 
     let input: serde_json::Value = match input_json {
-        Some(s) => serde_json::from_str(s)
-            .map_err(|e| KernelError::new(ErrorCode::MalformedJson, format!("invalid --json: {e}")))?,
+        Some(s) => serde_json::from_str(s).map_err(|e| {
+            KernelError::new(ErrorCode::MalformedJson, format!("invalid --json: {e}"))
+        })?,
         None => serde_json::json!({}),
     };
 
@@ -166,12 +176,45 @@ fn cmd_serve_stdio() -> anyhow::Result<()> {
     stdio::serve_stdio(ctx)
 }
 
+fn cmd_studio() -> anyhow::Result<()> {
+    let harmony_dir = harmony_core::root::RootResolver::resolve()?;
+    let runtime_dir = harmony_dir.join("runtime");
+    let manifest_path = runtime_dir.join("crates").join("Cargo.toml");
+    let target_dir = runtime_dir
+        .join("_ops")
+        .join("state")
+        .join("build")
+        .join("runtime-crates-target");
+
+    std::fs::create_dir_all(&target_dir)?;
+
+    let status = ProcessCommand::new("cargo")
+        .arg("run")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .arg("-p")
+        .arg("harmony_studio")
+        .arg("--bin")
+        .arg("harmony-studio")
+        .current_dir(&harmony_dir)
+        .env("CARGO_TARGET_DIR", target_dir)
+        .status()?;
+
+    if !status.success() {
+        anyhow::bail!("harmony studio exited with status {}", status);
+    }
+
+    Ok(())
+}
+
 fn cmd_service(cmd: ServiceCmd) -> anyhow::Result<()> {
     let harmony_dir = harmony_core::root::RootResolver::resolve()?;
     match cmd {
         ServiceCmd::New { category, name } => {
             scaffold::service_new(&harmony_dir, &category, &name)?;
-            println!("created service scaffold at .harmony/capabilities/services/{category}/{name}");
+            println!(
+                "created service scaffold at .harmony/capabilities/services/{category}/{name}"
+            );
         }
         ServiceCmd::Build { target, name } => {
             let (category, name) = parse_category_name(&target, name.as_deref())?;
@@ -201,4 +244,37 @@ fn parse_category_name(target: &str, name: Option<&str>) -> anyhow::Result<(Stri
     }
 
     Ok((target.to_string(), name.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Command};
+    use clap::{CommandFactory, Parser};
+
+    #[test]
+    fn cli_parses_studio_subcommand() {
+        let cli = Cli::try_parse_from(["harmony", "studio"])
+            .expect("studio subcommand should parse successfully");
+        assert!(
+            matches!(cli.cmd, Command::Studio),
+            "parsed command should be Studio"
+        );
+    }
+
+    #[test]
+    fn cli_help_lists_studio_command() {
+        let mut cmd = Cli::command();
+        let mut help = Vec::new();
+        cmd.write_long_help(&mut help)
+            .expect("long help should render");
+        let help = String::from_utf8(help).expect("help should be valid utf-8");
+        assert!(
+            help.contains("studio"),
+            "help output should contain studio command"
+        );
+        assert!(
+            help.contains("Launch Harmony Studio desktop UI"),
+            "help output should include studio description"
+        );
+    }
 }

--- a/.harmony/runtime/crates/studio/Cargo.toml
+++ b/.harmony/runtime/crates/studio/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "harmony_studio"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+build = "build.rs"
+
+[[bin]]
+name = "harmony-studio"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+serde.workspace = true
+serde_yaml.workspace = true
+walkdir.workspace = true
+slint = "1.10"
+
+[build-dependencies]
+slint-build = "1.10"

--- a/.harmony/runtime/crates/studio/README.md
+++ b/.harmony/runtime/crates/studio/README.md
@@ -1,0 +1,34 @@
+# harmony_studio
+
+Desktop workflow studio for Harmony harness projects.
+
+## Scope
+
+- Workflow inventory and validation overview
+- Dependency graph canvas with pan/zoom/select
+- Workflow detail inspector from parsed `WORKFLOW.md` frontmatter steps
+- Staged edit buffer with patch preview export
+- Guarded apply flow with transactional rollback
+- Apply audit index, filtering, preview, and path actions
+
+## Run
+
+From repository root:
+
+```bash
+.harmony/runtime/run studio
+```
+
+From runtime crates workspace:
+
+```bash
+cargo run -p harmony_studio
+```
+
+## Verify
+
+```bash
+cargo fmt -p harmony_studio
+cargo check -p harmony_studio
+cargo test -p harmony_studio
+```

--- a/.harmony/runtime/crates/studio/build.rs
+++ b/.harmony/runtime/crates/studio/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    slint_build::compile("ui/app.slint").expect("failed to compile Slint UI");
+}

--- a/.harmony/runtime/crates/studio/src/app_state.rs
+++ b/.harmony/runtime/crates/studio/src/app_state.rs
@@ -1,0 +1,1264 @@
+use crate::graph::layout::{layered_layout, Edge, Node, PositionedNode};
+use crate::staging::{list_recent_apply_audits, ApplyAuditSummary, StagedEditBuffer};
+use crate::workflows::{
+    load_workflow_index, validate_snapshot, ValidationIssue, WorkflowIndexSnapshot, WorkflowSummary,
+};
+use anyhow::{anyhow, Result};
+use serde_yaml::{Mapping, Value};
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command as ProcessCommand, Stdio};
+
+const MIN_ZOOM: f32 = 0.55;
+const MAX_ZOOM: f32 = 2.4;
+const PATCH_PREVIEW_LIMIT: usize = 18_000;
+const AUDIT_LIST_LIMIT: usize = 6;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuditStatusFilter {
+    All,
+    AppliedOnly,
+    FailedOnly,
+}
+
+impl AuditStatusFilter {
+    fn from_mode(mode: i32) -> Self {
+        match mode {
+            1 => Self::AppliedOnly,
+            2 => Self::FailedOnly,
+            _ => Self::All,
+        }
+    }
+
+    fn mode(self) -> i32 {
+        match self {
+            Self::All => 0,
+            Self::AppliedOnly => 1,
+            Self::FailedOnly => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowListItemState {
+    pub id: String,
+    pub label: String,
+    pub selected: bool,
+    pub issue_count: i32,
+    pub step_count: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphNodeState {
+    pub id: String,
+    pub label: String,
+    pub x: f32,
+    pub y: f32,
+    pub selected: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct InspectorStepState {
+    pub id: String,
+    pub file: String,
+    pub status: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct InspectorIssueState {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApplyAuditItemState {
+    pub path: String,
+    pub status: String,
+    pub summary: String,
+    pub selected: bool,
+}
+
+pub struct AppState {
+    root: PathBuf,
+    snapshot: WorkflowIndexSnapshot,
+    issues: Vec<ValidationIssue>,
+    base_layout: Vec<PositionedNode>,
+    edges: Vec<Edge>,
+    selected_workflow_id: Option<String>,
+    pan_x: f32,
+    pan_y: f32,
+    zoom: f32,
+    staged_edits: StagedEditBuffer,
+    apply_armed: bool,
+    recent_audits: Vec<ApplyAuditSummary>,
+    audit_filter_query: String,
+    audit_status_filter: AuditStatusFilter,
+    selected_audit_index: Option<usize>,
+    selected_audit_path: String,
+    selected_audit_preview: String,
+    patch_preview: String,
+    export_status: String,
+}
+
+impl AppState {
+    pub fn load(root: PathBuf) -> Result<Self> {
+        let snapshot = load_workflow_index(&root)?;
+        let issues = validate_snapshot(&snapshot);
+        let (base_layout, edges) = build_graph_layout(&snapshot);
+        let selected_workflow_id = snapshot
+            .workflows
+            .first()
+            .map(|workflow| workflow.id.clone());
+        let recent_audits = list_recent_apply_audits(&root, 10).unwrap_or_default();
+
+        let mut state = Self {
+            root,
+            snapshot,
+            issues,
+            base_layout,
+            edges,
+            selected_workflow_id,
+            pan_x: 0.0,
+            pan_y: 0.0,
+            zoom: 1.0,
+            staged_edits: StagedEditBuffer::default(),
+            apply_armed: false,
+            recent_audits,
+            audit_filter_query: String::new(),
+            audit_status_filter: AuditStatusFilter::All,
+            selected_audit_index: None,
+            selected_audit_path: "No audit selected".to_string(),
+            selected_audit_preview: "# Select an audit entry to preview markdown.\n".to_string(),
+            patch_preview: "# No staged edits.\n".to_string(),
+            export_status: "No staged edits yet.".to_string(),
+        };
+        state.sync_selected_audit_after_reload(None);
+        Ok(state)
+    }
+
+    pub fn root_display(&self) -> String {
+        self.root.display().to_string()
+    }
+
+    pub fn workflow_count(&self) -> usize {
+        self.snapshot.workflows.len()
+    }
+
+    pub fn issue_count(&self) -> usize {
+        self.issues.len()
+    }
+
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+
+    pub fn staged_edit_count(&self) -> usize {
+        self.staged_edits.len()
+    }
+
+    pub fn apply_armed(&self) -> bool {
+        self.apply_armed
+    }
+
+    pub fn patch_preview_text(&self) -> String {
+        if self.patch_preview.len() <= PATCH_PREVIEW_LIMIT {
+            return self.patch_preview.clone();
+        }
+        let mut preview = self.patch_preview[..PATCH_PREVIEW_LIMIT].to_string();
+        preview.push_str("\n# ... preview truncated ...\n");
+        preview
+    }
+
+    pub fn export_status_text(&self) -> String {
+        self.export_status.clone()
+    }
+
+    pub fn audit_count(&self) -> usize {
+        self.filtered_audit_indices().len()
+    }
+
+    pub fn audit_filter_query_text(&self) -> String {
+        self.audit_filter_query.clone()
+    }
+
+    pub fn audit_status_filter_mode(&self) -> i32 {
+        self.audit_status_filter.mode()
+    }
+
+    pub fn audit_items(&self) -> Vec<ApplyAuditItemState> {
+        self.filtered_audit_indices()
+            .into_iter()
+            .take(AUDIT_LIST_LIMIT)
+            .filter_map(|audit_index| {
+                self.recent_audits
+                    .get(audit_index)
+                    .map(|audit| (audit_index, audit))
+            })
+            .map(|(audit_index, audit)| ApplyAuditItemState {
+                path: audit.path.display().to_string(),
+                status: audit.status.clone(),
+                summary: if let Some(timestamp) = audit.timestamp_unix_ms {
+                    format!("[{timestamp}] {}", audit.summary)
+                } else {
+                    audit.summary.clone()
+                },
+                selected: self.selected_audit_index == Some(audit_index),
+            })
+            .collect()
+    }
+
+    pub fn selected_audit_path_text(&self) -> String {
+        self.selected_audit_path.clone()
+    }
+
+    pub fn selected_audit_preview_text(&self) -> String {
+        self.selected_audit_preview.clone()
+    }
+
+    pub fn workflow_list_items(&self) -> Vec<WorkflowListItemState> {
+        self.snapshot
+            .workflows
+            .iter()
+            .map(|workflow| {
+                let step_count = workflow
+                    .document
+                    .as_ref()
+                    .map_or(0, |document| document.steps.len())
+                    as i32;
+                WorkflowListItemState {
+                    id: workflow.id.clone(),
+                    label: workflow.id.clone(),
+                    selected: self.selected_workflow_id.as_deref() == Some(workflow.id.as_str()),
+                    issue_count: self.issue_count_for_workflow(&workflow.id) as i32,
+                    step_count,
+                }
+            })
+            .collect()
+    }
+
+    pub fn graph_node_items(&self) -> Vec<GraphNodeState> {
+        let mut workflow_by_id = HashMap::new();
+        for workflow in &self.snapshot.workflows {
+            workflow_by_id.insert(workflow.id.as_str(), workflow);
+        }
+
+        self.base_layout
+            .iter()
+            .map(|position| {
+                let label = workflow_by_id
+                    .get(position.id.as_str())
+                    .map(|workflow| workflow.id.clone())
+                    .unwrap_or_else(|| position.id.clone());
+                GraphNodeState {
+                    id: position.id.clone(),
+                    label,
+                    x: position.x * self.zoom + self.pan_x,
+                    y: position.y * self.zoom + self.pan_y,
+                    selected: self.selected_workflow_id.as_deref() == Some(position.id.as_str()),
+                }
+            })
+            .collect()
+    }
+
+    pub fn selected_title(&self) -> String {
+        if let Some(workflow) = self.selected_workflow() {
+            if let Some(document) = &workflow.document {
+                if let Some(name) = &document.name {
+                    if !name.trim().is_empty() {
+                        return format!("{name} ({})", workflow.id);
+                    }
+                }
+            }
+            return workflow.id.clone();
+        }
+        "No workflow selected".to_string()
+    }
+
+    pub fn selected_description(&self) -> String {
+        if let Some(workflow) = self.selected_workflow() {
+            if let Some(document) = &workflow.document {
+                if let Some(description) = &document.description {
+                    if !description.trim().is_empty() {
+                        return description.clone();
+                    }
+                }
+            }
+            return "Workflow frontmatter did not provide a description.".to_string();
+        }
+        "Select a workflow from the left list or graph canvas.".to_string()
+    }
+
+    pub fn selected_path(&self) -> String {
+        if let Some(workflow) = self.selected_workflow() {
+            let mut segments = vec![
+                format!("workflow file: {}", workflow.workflow_file.display()),
+                format!("workflow dir: {}", workflow.workflow_dir.display()),
+            ];
+            if let Some(path_hint) = &workflow.manifest_path_hint {
+                segments.push(format!("manifest path hint: {path_hint}"));
+            }
+            if let Some(path_hint) = &workflow.registry_path_hint {
+                segments.push(format!("registry path hint: {path_hint}"));
+            }
+            return segments.join(" | ");
+        }
+        "-".to_string()
+    }
+
+    pub fn selected_dependency_summary(&self) -> String {
+        if let Some(workflow) = self.selected_workflow() {
+            if workflow.dependencies.is_empty() {
+                return "Dependencies: none".to_string();
+            }
+            return format!("Dependencies: {}", workflow.dependencies.join(", "));
+        }
+        "Dependencies: -".to_string()
+    }
+
+    pub fn selected_steps(&self) -> Vec<InspectorStepState> {
+        let Some(workflow) = self.selected_workflow() else {
+            return Vec::new();
+        };
+        let Some(document) = &workflow.document else {
+            return Vec::new();
+        };
+
+        document
+            .steps
+            .iter()
+            .map(|step| InspectorStepState {
+                id: step.id.clone(),
+                file: step.file.clone(),
+                status: if step.exists {
+                    "ok".to_string()
+                } else {
+                    "missing".to_string()
+                },
+                description: step.description.clone().unwrap_or_default(),
+            })
+            .collect()
+    }
+
+    pub fn selected_issues(&self) -> Vec<InspectorIssueState> {
+        let selected_id = self.selected_workflow_id.as_deref();
+        self.issues
+            .iter()
+            .filter(|issue| issue.workflow_id.as_deref() == selected_id)
+            .map(|issue| InspectorIssueState {
+                code: issue.code.to_string(),
+                message: if let Some(path) = &issue.path {
+                    format!("{} [{}]", issue.message, path.display())
+                } else {
+                    issue.message.clone()
+                },
+            })
+            .collect()
+    }
+
+    pub fn selected_issue_count(&self) -> usize {
+        self.selected_issues().len()
+    }
+
+    pub fn zoom_percent(&self) -> i32 {
+        (self.zoom * 100.0).round() as i32
+    }
+
+    pub fn select_workflow(&mut self, workflow_id: &str) {
+        self.selected_workflow_id = Some(workflow_id.to_string());
+    }
+
+    pub fn pan_by(&mut self, delta_x: f32, delta_y: f32) {
+        self.pan_x = (self.pan_x + delta_x).clamp(-1800.0, 1800.0);
+        self.pan_y = (self.pan_y + delta_y).clamp(-1400.0, 1400.0);
+    }
+
+    pub fn zoom_by(&mut self, factor: f32) {
+        self.zoom = (self.zoom * factor).clamp(MIN_ZOOM, MAX_ZOOM);
+    }
+
+    pub fn reset_view(&mut self) {
+        self.pan_x = 0.0;
+        self.pan_y = 0.0;
+        self.zoom = 1.0;
+    }
+
+    pub fn stage_selected_safe_edits(&mut self) -> Result<()> {
+        let Some(workflow) = self.selected_workflow().cloned() else {
+            self.apply_armed = false;
+            self.export_status = "Select a workflow before staging edits.".to_string();
+            return Ok(());
+        };
+
+        let existing_edit_count = self.staged_edits.len();
+        let mut touched_targets = 0usize;
+
+        if workflow.has_workflow_file {
+            let original = match fs::read_to_string(&workflow.workflow_file) {
+                Ok(contents) => contents,
+                Err(error) => {
+                    self.export_status = format!(
+                        "Failed to read {}: {error}",
+                        workflow.workflow_file.display()
+                    );
+                    return Err(error.into());
+                }
+            };
+            let normalized = normalize_workflow_markdown(&workflow.id, &original);
+            self.staged_edits.stage_update(
+                workflow.workflow_file.clone(),
+                original,
+                normalized,
+                "Normalize WORKFLOW.md frontmatter defaults".to_string(),
+            );
+            touched_targets += 1;
+        } else {
+            self.staged_edits.stage_create(
+                workflow.workflow_file.clone(),
+                workflow_file_template(&workflow.id),
+                "Create missing WORKFLOW.md from safe template".to_string(),
+            );
+            touched_targets += 1;
+        }
+
+        if let Some(document) = workflow.document {
+            for step in document.steps {
+                if !step.exists {
+                    self.staged_edits.stage_create(
+                        step.path.clone(),
+                        step_file_template(&step.id, step.description.as_deref()),
+                        format!("Create missing step file '{}'", step.file),
+                    );
+                    touched_targets += 1;
+                }
+            }
+        }
+
+        self.refresh_patch_preview();
+        let total_staged = self.staged_edits.len();
+        let newly_staged = total_staged.saturating_sub(existing_edit_count);
+        self.apply_armed = false;
+        if total_staged == 0 {
+            self.export_status = format!("No staged edits were needed for '{}'.", workflow.id);
+        } else {
+            self.export_status = format!(
+                "Staged {} new edits ({} total) across {} targets for '{}'.",
+                newly_staged, total_staged, touched_targets, workflow.id
+            );
+        }
+
+        Ok(())
+    }
+
+    pub fn clear_staged_edits(&mut self) {
+        self.staged_edits.clear();
+        self.apply_armed = false;
+        self.refresh_patch_preview();
+        self.export_status = "Cleared staged edit buffer.".to_string();
+    }
+
+    pub fn export_patch_preview(&mut self) -> Result<()> {
+        if self.staged_edits.is_empty() {
+            self.export_status = "No staged edits to export.".to_string();
+            return Ok(());
+        }
+
+        let path = match self.staged_edits.export_patch_preview(&self.root) {
+            Ok(path) => path,
+            Err(error) => {
+                self.export_status = format!("Failed to export patch preview: {error}");
+                return Err(error);
+            }
+        };
+        self.export_status = format!("Patch preview exported to {}.", path.display());
+        Ok(())
+    }
+
+    pub fn refresh_audit_index(&mut self) {
+        let preferred = self.current_selected_audit_path();
+        match list_recent_apply_audits(&self.root, 10) {
+            Ok(audits) => {
+                self.recent_audits = audits;
+                self.sync_selected_audit_after_reload(preferred.as_deref());
+                self.export_status =
+                    format!("Reloaded {} apply audit records.", self.recent_audits.len());
+            }
+            Err(error) => {
+                self.export_status = format!("Failed to reload apply audits: {error}");
+            }
+        }
+    }
+
+    pub fn set_audit_filter_query(&mut self, query: &str) {
+        self.audit_filter_query = query.to_string();
+        let preferred = self.current_selected_audit_path();
+        self.sync_selected_audit_after_reload(preferred.as_deref());
+        self.export_status = format!(
+            "Audit search query updated ({} matches).",
+            self.audit_count()
+        );
+    }
+
+    pub fn set_audit_status_filter(&mut self, mode: i32) {
+        self.audit_status_filter = AuditStatusFilter::from_mode(mode);
+        let preferred = self.current_selected_audit_path();
+        self.sync_selected_audit_after_reload(preferred.as_deref());
+        self.export_status = format!(
+            "Audit status filter updated ({} matches).",
+            self.audit_count()
+        );
+    }
+
+    pub fn select_audit(&mut self, index: i32) {
+        if index < 0 {
+            self.export_status = format!("Invalid audit selection index: {index}");
+            return;
+        }
+        let index = index as usize;
+        let visible = self
+            .filtered_audit_indices()
+            .into_iter()
+            .take(AUDIT_LIST_LIMIT)
+            .collect::<Vec<_>>();
+        if index >= visible.len() {
+            self.export_status = format!("Invalid audit selection index: {index}");
+            return;
+        }
+
+        self.selected_audit_index = Some(visible[index]);
+        self.refresh_selected_audit_preview();
+        self.export_status = format!("Selected audit: {}", self.selected_audit_path);
+    }
+
+    pub fn open_selected_audit_location(&mut self) -> Result<()> {
+        let Some(path) = self.current_selected_audit_path() else {
+            self.export_status = "No audit selected to open.".to_string();
+            return Ok(());
+        };
+
+        if let Err(error) = reveal_path_in_system(&path) {
+            self.export_status = format!("Failed to open audit location: {error}");
+            return Err(error);
+        }
+
+        self.export_status = format!("Opened audit location for {}.", path.display());
+        Ok(())
+    }
+
+    pub fn copy_selected_audit_path(&mut self) -> Result<()> {
+        let Some(path) = self.current_selected_audit_path() else {
+            self.export_status = "No audit selected to copy.".to_string();
+            return Ok(());
+        };
+
+        let path_text = path.display().to_string();
+        if let Err(error) = copy_text_to_clipboard(&path_text) {
+            self.export_status = format!("Failed to copy audit path: {error}");
+            return Err(error);
+        }
+
+        self.export_status = format!("Copied audit path to clipboard: {}", path.display());
+        Ok(())
+    }
+
+    pub fn toggle_apply_arm(&mut self) {
+        if self.staged_edits.is_empty() {
+            self.apply_armed = false;
+            self.export_status = "No staged edits to arm.".to_string();
+            return;
+        }
+
+        self.apply_armed = !self.apply_armed;
+        self.export_status = if self.apply_armed {
+            "Apply is armed. Click 'Apply to Files' to write staged edits.".to_string()
+        } else {
+            "Apply disarmed.".to_string()
+        };
+    }
+
+    pub fn apply_staged_edits(&mut self) -> Result<()> {
+        if self.staged_edits.is_empty() {
+            self.apply_armed = false;
+            self.export_status = "No staged edits to apply.".to_string();
+            return Ok(());
+        }
+
+        if !self.apply_armed {
+            self.export_status = "Apply is disarmed. Arm apply before writing files.".to_string();
+            return Ok(());
+        }
+
+        let report = match self.staged_edits.apply_to_disk(&self.root) {
+            Ok(report) => report,
+            Err(error) => {
+                self.apply_armed = false;
+                self.refresh_recent_audits_silent();
+                self.export_status = format!("Apply failed: {error}");
+                return Err(error);
+            }
+        };
+
+        self.staged_edits.clear();
+        self.apply_armed = false;
+        self.refresh_patch_preview();
+        self.refresh_recent_audits_silent();
+
+        if let Err(error) = self.reload_snapshot_from_disk() {
+            self.export_status = format!(
+                "Applied {} staged edits (audit: {}), but failed to reload workflow state: {error}",
+                report.applied_files,
+                report.audit_path.display()
+            );
+            return Err(error);
+        }
+
+        self.export_status = format!(
+            "Applied {} staged edits ({} attempted, rollback {}). Audit: {}",
+            report.applied_files,
+            report.attempted_files,
+            report.rolled_back_files,
+            report.audit_path.display()
+        );
+        Ok(())
+    }
+
+    pub fn status_line(&self) -> String {
+        let selected = self
+            .selected_workflow_id
+            .as_deref()
+            .map_or("none", |value| value);
+        format!(
+            "Loaded {} workflows; {} edges; {} validation issues; staged={}; apply_armed={}; selected={}; zoom={}%.",
+            self.snapshot.workflows.len(),
+            self.edges.len(),
+            self.issues.len(),
+            self.staged_edits.len(),
+            self.apply_armed,
+            selected,
+            self.zoom_percent(),
+        )
+    }
+
+    fn selected_workflow(&self) -> Option<&WorkflowSummary> {
+        let selected = self.selected_workflow_id.as_deref()?;
+        self.snapshot
+            .workflows
+            .iter()
+            .find(|workflow| workflow.id == selected)
+    }
+
+    fn issue_count_for_workflow(&self, workflow_id: &str) -> usize {
+        self.issues
+            .iter()
+            .filter(|issue| issue.workflow_id.as_deref() == Some(workflow_id))
+            .count()
+    }
+
+    fn refresh_patch_preview(&mut self) {
+        self.patch_preview = self.staged_edits.render_unified_patch(&self.root);
+    }
+
+    fn refresh_recent_audits_silent(&mut self) {
+        let preferred = self.current_selected_audit_path();
+        if let Ok(audits) = list_recent_apply_audits(&self.root, 10) {
+            self.recent_audits = audits;
+            self.sync_selected_audit_after_reload(preferred.as_deref());
+        }
+    }
+
+    fn current_selected_audit_path(&self) -> Option<PathBuf> {
+        self.selected_audit_index
+            .and_then(|index| self.recent_audits.get(index))
+            .map(|audit| audit.path.clone())
+    }
+
+    fn filtered_audit_indices(&self) -> Vec<usize> {
+        let query = self.audit_filter_query.trim().to_lowercase();
+        self.recent_audits
+            .iter()
+            .enumerate()
+            .filter(|(_, audit)| {
+                let status_ok = match self.audit_status_filter {
+                    AuditStatusFilter::All => true,
+                    AuditStatusFilter::AppliedOnly => audit.status == "applied",
+                    AuditStatusFilter::FailedOnly => audit.status != "applied",
+                };
+                if !status_ok {
+                    return false;
+                }
+
+                if query.is_empty() {
+                    return true;
+                }
+
+                let haystack = format!(
+                    "{} {} {}",
+                    audit.path.display(),
+                    audit.status,
+                    audit.summary
+                )
+                .to_lowercase();
+                haystack.contains(&query)
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    fn sync_selected_audit_after_reload(&mut self, preferred_path: Option<&Path>) {
+        let filtered = self.filtered_audit_indices();
+        if filtered.is_empty() {
+            self.selected_audit_index = None;
+            self.selected_audit_path = "No audit selected".to_string();
+            self.selected_audit_preview = "# No apply audits match current filters.\n".to_string();
+            return;
+        }
+
+        let selected = preferred_path
+            .and_then(|path| {
+                filtered.iter().copied().find(|index| {
+                    self.recent_audits
+                        .get(*index)
+                        .is_some_and(|audit| audit.path == path)
+                })
+            })
+            .or_else(|| {
+                self.selected_audit_index
+                    .filter(|index| filtered.contains(index))
+            })
+            .unwrap_or(filtered[0]);
+
+        self.selected_audit_index = Some(selected);
+        self.refresh_selected_audit_preview();
+    }
+
+    fn refresh_selected_audit_preview(&mut self) {
+        let Some(index) = self.selected_audit_index else {
+            self.selected_audit_path = "No audit selected".to_string();
+            self.selected_audit_preview = "# No apply audit selected.\n".to_string();
+            return;
+        };
+        let Some(audit) = self.recent_audits.get(index) else {
+            self.selected_audit_index = None;
+            self.selected_audit_path = "No audit selected".to_string();
+            self.selected_audit_preview = "# No apply audit selected.\n".to_string();
+            return;
+        };
+
+        self.selected_audit_path = audit.path.display().to_string();
+        self.selected_audit_preview = match fs::read_to_string(&audit.path) {
+            Ok(markdown) => markdown,
+            Err(error) => format!(
+                "# Failed to read audit\n\npath: {}\nerror: {error}",
+                audit.path.display()
+            ),
+        };
+    }
+
+    fn reload_snapshot_from_disk(&mut self) -> Result<()> {
+        let snapshot = load_workflow_index(&self.root)?;
+        let issues = validate_snapshot(&snapshot);
+        let (base_layout, edges) = build_graph_layout(&snapshot);
+
+        let selected = self.selected_workflow_id.clone();
+        let selected_workflow_id = selected
+            .filter(|workflow_id| snapshot.workflows.iter().any(|w| &w.id == workflow_id))
+            .or_else(|| {
+                snapshot
+                    .workflows
+                    .first()
+                    .map(|workflow| workflow.id.clone())
+            });
+
+        self.snapshot = snapshot;
+        self.issues = issues;
+        self.base_layout = base_layout;
+        self.edges = edges;
+        self.selected_workflow_id = selected_workflow_id;
+        Ok(())
+    }
+}
+
+fn build_graph_layout(snapshot: &WorkflowIndexSnapshot) -> (Vec<PositionedNode>, Vec<Edge>) {
+    let nodes: Vec<Node> = snapshot
+        .workflows
+        .iter()
+        .map(|workflow| Node {
+            id: workflow.id.clone(),
+        })
+        .collect();
+
+    let mut edges = Vec::new();
+    for workflow in &snapshot.workflows {
+        for dependency in &workflow.dependencies {
+            edges.push(Edge {
+                from: dependency.clone(),
+                to: workflow.id.clone(),
+            });
+        }
+    }
+
+    let base_layout = layered_layout(&nodes, &edges);
+    (base_layout, edges)
+}
+
+fn workflow_file_template(workflow_id: &str) -> String {
+    format!(
+        "---\nname: {workflow_id}\ndescription: TODO: describe what this workflow does and when to use it.\nsteps: []\n---\n\n# {workflow_id}\n\nAdd workflow overview and numbered step files.\n"
+    )
+}
+
+fn step_file_template(step_id: &str, description: Option<&str>) -> String {
+    let desc = description
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("TODO: describe {step_id} step behavior."));
+
+    format!(
+        "---\nname: {step_id}\ndescription: {desc}\n---\n\n# Step: {step_id}\n\n## Purpose\n- {desc}\n\n## Actions\n1. TODO: implement this step.\n\n## Idempotency\n- Check: verify whether outputs already exist.\n- If Already Complete: skip execution and continue.\n- Marker: checkpoints/<workflow-id>/{step_id}.complete\n"
+    )
+}
+
+fn normalize_workflow_markdown(workflow_id: &str, markdown: &str) -> String {
+    let Some((frontmatter_yaml, body)) = split_frontmatter(markdown) else {
+        return format!(
+            "---\nname: {workflow_id}\ndescription: TODO: describe what this workflow does and when to use it.\nsteps: []\n---\n\n{}",
+            markdown.trim_start_matches('\n')
+        );
+    };
+
+    let Ok(mut parsed) = serde_yaml::from_str::<Value>(&frontmatter_yaml) else {
+        return markdown.to_string();
+    };
+    let Some(mapping) = parsed.as_mapping_mut() else {
+        return markdown.to_string();
+    };
+
+    ensure_frontmatter_description(mapping, workflow_id);
+    ensure_step_descriptions(mapping);
+
+    let Ok(mut serialized) = serde_yaml::to_string(&parsed) else {
+        return markdown.to_string();
+    };
+    if let Some(stripped) = serialized.strip_prefix("---\n") {
+        serialized = stripped.to_string();
+    }
+    let serialized = serialized.trim_end_matches('\n');
+    let body = body.trim_start_matches('\n');
+
+    if body.is_empty() {
+        format!("---\n{serialized}\n---\n")
+    } else {
+        format!("---\n{serialized}\n---\n\n{body}")
+    }
+}
+
+fn split_frontmatter(markdown: &str) -> Option<(String, String)> {
+    let mut lines = markdown.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+
+    let mut yaml_lines = Vec::new();
+    let mut body_start = None;
+    let source_lines: Vec<&str> = markdown.lines().collect();
+    for (index, line) in source_lines.iter().enumerate().skip(1) {
+        if line.trim() == "---" {
+            body_start = Some(index + 1);
+            break;
+        }
+        yaml_lines.push(*line);
+    }
+
+    let body_start = body_start?;
+    let body = source_lines[body_start..].join("\n");
+    Some((yaml_lines.join("\n"), body))
+}
+
+fn ensure_frontmatter_description(mapping: &mut Mapping, workflow_id: &str) {
+    let key = Value::String("description".to_string());
+    let current = mapping.get(&key).and_then(Value::as_str).map(str::trim);
+    if current.is_none_or(|value| value.is_empty()) {
+        mapping.insert(
+            key,
+            Value::String(format!(
+                "TODO: describe workflow '{workflow_id}' and when to use it."
+            )),
+        );
+    }
+}
+
+fn ensure_step_descriptions(mapping: &mut Mapping) {
+    let steps_key = Value::String("steps".to_string());
+    let Some(steps) = mapping.get_mut(&steps_key).and_then(Value::as_sequence_mut) else {
+        return;
+    };
+
+    let id_key = Value::String("id".to_string());
+    let desc_key = Value::String("description".to_string());
+
+    for step in steps {
+        let Some(step_mapping) = step.as_mapping_mut() else {
+            continue;
+        };
+
+        let step_id = step_mapping
+            .get(&id_key)
+            .and_then(Value::as_str)
+            .unwrap_or("step");
+        let current = step_mapping
+            .get(&desc_key)
+            .and_then(Value::as_str)
+            .map(str::trim);
+        if current.is_none_or(|value| value.is_empty()) {
+            step_mapping.insert(
+                desc_key.clone(),
+                Value::String(format!("TODO: describe {step_id} step behavior.")),
+            );
+        }
+    }
+}
+
+fn copy_text_to_clipboard(text: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        return copy_text_with_stdin(ProcessCommand::new("pbcopy"), text);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let wl_copy = copy_text_with_stdin(ProcessCommand::new("wl-copy"), text);
+        if wl_copy.is_ok() {
+            return Ok(());
+        }
+
+        let xclip = copy_text_with_stdin(
+            {
+                let mut cmd = ProcessCommand::new("xclip");
+                cmd.arg("-selection").arg("clipboard");
+                cmd
+            },
+            text,
+        );
+        if xclip.is_ok() {
+            return Ok(());
+        }
+
+        let xsel = copy_text_with_stdin(
+            {
+                let mut cmd = ProcessCommand::new("xsel");
+                cmd.arg("--clipboard").arg("--input");
+                cmd
+            },
+            text,
+        );
+        if xsel.is_ok() {
+            return Ok(());
+        }
+
+        return Err(anyhow!(
+            "failed to copy via wl-copy/xclip/xsel; install one clipboard utility"
+        ));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return copy_text_with_stdin(
+            {
+                let mut cmd = ProcessCommand::new("powershell");
+                cmd.arg("-NoProfile").arg("-Command").arg("Set-Clipboard");
+                cmd
+            },
+            text,
+        );
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = text;
+        Err(anyhow!("clipboard copy is unsupported on this OS"))
+    }
+}
+
+fn copy_text_with_stdin(mut command: ProcessCommand, text: &str) -> Result<()> {
+    let mut child = command.stdin(Stdio::piped()).spawn()?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(text.as_bytes())?;
+    }
+    let status = child.wait()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("clipboard command exited with status {}", status))
+    }
+}
+
+fn reveal_path_in_system(path: &Path) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let status = ProcessCommand::new("open").arg("-R").arg(path).status()?;
+        if status.success() {
+            return Ok(());
+        }
+        return Err(anyhow!("'open -R' exited with status {}", status));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let target = path.parent().unwrap_or(path);
+        let status = ProcessCommand::new("xdg-open").arg(target).status()?;
+        if status.success() {
+            return Ok(());
+        }
+        return Err(anyhow!("'xdg-open' exited with status {}", status));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let arg = format!("/select,{}", path.display());
+        let status = ProcessCommand::new("explorer").arg(arg).status()?;
+        if status.success() {
+            return Ok(());
+        }
+        return Err(anyhow!("'explorer /select' exited with status {}", status));
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = path;
+        Err(anyhow!("opening file locations is unsupported on this OS"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppState;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempHarness {
+        root: PathBuf,
+    }
+
+    impl TempHarness {
+        fn new(label: &str) -> Self {
+            let stamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be valid")
+                .as_nanos();
+            let pid = std::process::id();
+            let root = std::env::temp_dir().join(format!("harmony-studio-{label}-{pid}-{stamp}"));
+            fs::create_dir_all(&root).expect("temp root should be created");
+            write_fixture_harness(&root);
+            Self { root }
+        }
+
+        fn root_path(&self) -> PathBuf {
+            self.root.clone()
+        }
+    }
+
+    impl Drop for TempHarness {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn app_state_loads_workflow_inspector_and_graph_models() {
+        let harness = TempHarness::new("inspector-graph");
+        let mut state = AppState::load(harness.root_path()).expect("app state should load");
+
+        assert_eq!(
+            state.workflow_count(),
+            2,
+            "fixture should define two workflows"
+        );
+        assert_eq!(
+            state.edge_count(),
+            1,
+            "registry dependency should create one edge"
+        );
+        assert_eq!(state.selected_title(), "Alpha Flow (alpha)");
+        assert_eq!(state.selected_issue_count(), 0);
+        assert_eq!(state.selected_steps().len(), 1);
+        assert_eq!(state.selected_steps()[0].status, "ok");
+
+        state.select_workflow("beta");
+        assert_eq!(state.selected_title(), "Beta Flow (beta)");
+        assert_eq!(
+            state.selected_dependency_summary(),
+            "Dependencies: alpha",
+            "beta should show alpha dependency"
+        );
+        assert_eq!(
+            state.selected_issue_count(),
+            1,
+            "beta should surface missing-step-file validation"
+        );
+        assert_eq!(state.selected_steps().len(), 1);
+        assert_eq!(state.selected_steps()[0].status, "missing");
+
+        let graph_nodes = state.graph_node_items();
+        assert_eq!(graph_nodes.len(), 2);
+        assert!(
+            graph_nodes
+                .iter()
+                .any(|node| node.id == "beta" && node.selected),
+            "selected workflow should be reflected in graph model"
+        );
+    }
+
+    #[test]
+    fn graph_pan_zoom_reset_updates_positions() {
+        let harness = TempHarness::new("graph-pan-zoom");
+        let mut state = AppState::load(harness.root_path()).expect("app state should load");
+
+        let baseline_nodes = state.graph_node_items();
+        let baseline_alpha = baseline_nodes
+            .iter()
+            .find(|node| node.id == "alpha")
+            .expect("alpha node should exist");
+
+        state.pan_by(120.0, -80.0);
+        state.zoom_by(1.5);
+
+        let moved_alpha = state
+            .graph_node_items()
+            .into_iter()
+            .find(|node| node.id == "alpha")
+            .expect("alpha node should exist after pan/zoom");
+        assert!(
+            (moved_alpha.x - baseline_alpha.x).abs() > 0.01
+                || (moved_alpha.y - baseline_alpha.y).abs() > 0.01,
+            "pan/zoom should move rendered graph coordinates"
+        );
+
+        state.zoom_by(100.0);
+        assert_eq!(state.zoom_percent(), 240, "zoom should clamp to max");
+        state.zoom_by(0.0001);
+        assert_eq!(state.zoom_percent(), 55, "zoom should clamp to min");
+
+        state.reset_view();
+        assert_eq!(state.zoom_percent(), 100);
+        let reset_alpha = state
+            .graph_node_items()
+            .into_iter()
+            .find(|node| node.id == "alpha")
+            .expect("alpha node should exist after reset");
+        assert!((reset_alpha.x - baseline_alpha.x).abs() < 0.01);
+        assert!((reset_alpha.y - baseline_alpha.y).abs() < 0.01);
+    }
+
+    #[test]
+    fn audit_filter_and_selection_updates_preview() {
+        let harness = TempHarness::new("audit-filters");
+        write_fixture_audits(harness.root.as_path());
+
+        let mut state = AppState::load(harness.root_path()).expect("app state should load");
+        assert_eq!(state.audit_count(), 2);
+        assert!(
+            state.selected_audit_path_text().contains("1002-"),
+            "newest audit should be selected by default"
+        );
+
+        state.set_audit_status_filter(1);
+        assert_eq!(state.audit_count(), 1);
+        assert!(
+            state.selected_audit_path_text().contains("1001-"),
+            "applied filter should keep only applied audit"
+        );
+
+        state.set_audit_status_filter(2);
+        assert_eq!(state.audit_count(), 1);
+        assert!(
+            state.selected_audit_path_text().contains("1002-"),
+            "failed filter should keep only failed audit"
+        );
+
+        state.set_audit_status_filter(0);
+        state.set_audit_filter_query("rolled back");
+        assert_eq!(state.audit_count(), 1);
+        assert!(
+            state
+                .selected_audit_preview_text()
+                .contains("failed-rolled-back"),
+            "preview should show selected failed audit markdown"
+        );
+        state.select_audit(0);
+        assert_eq!(state.audit_items().len(), 1);
+        assert!(state.audit_items()[0].selected);
+    }
+
+    #[test]
+    fn staged_buffer_flow_requires_arm_and_supports_clear() {
+        let harness = TempHarness::new("staged-flow");
+        let mut state = AppState::load(harness.root_path()).expect("app state should load");
+
+        state.select_workflow("beta");
+        state
+            .stage_selected_safe_edits()
+            .expect("staging should succeed");
+        assert!(
+            state.staged_edit_count() >= 1,
+            "staging should buffer at least one safe edit"
+        );
+        assert!(
+            state.patch_preview_text().contains("diff --git"),
+            "patch preview should include staged diff output"
+        );
+        assert!(!state.apply_armed(), "staging should disarm apply");
+
+        state.toggle_apply_arm();
+        assert!(state.apply_armed(), "toggle should arm apply");
+
+        state.clear_staged_edits();
+        assert_eq!(state.staged_edit_count(), 0);
+        assert!(!state.apply_armed());
+        assert_eq!(state.patch_preview_text(), "# No staged edits.\n");
+    }
+
+    fn write_fixture_harness(root: &Path) {
+        write_file(
+            &root.join(".harmony/orchestration/workflows/manifest.yml"),
+            "workflows:\n  - id: alpha\n    path: alpha\n  - id: beta\n    path: beta\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/workflows/registry.yml"),
+            "workflows:\n  alpha:\n    path: alpha\n  beta:\n    path: beta\n    depends_on:\n      - workflow: alpha\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/workflows/alpha/WORKFLOW.md"),
+            "---\nname: Alpha Flow\ndescription: Alpha workflow for fixture tests.\nsteps:\n  - id: alpha-step\n    file: 01-alpha.md\n    description: Alpha step.\n---\n\n# Alpha\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/workflows/alpha/01-alpha.md"),
+            "---\nname: alpha-step\ndescription: Alpha step.\n---\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/workflows/beta/WORKFLOW.md"),
+            "---\nname: Beta Flow\ndescription: Beta workflow with a missing step file.\nsteps:\n  - id: beta-step\n    file: 01-beta.md\n    description: Beta missing step.\n---\n\n# Beta\n",
+        );
+    }
+
+    fn write_fixture_audits(root: &Path) {
+        write_file(
+            &root.join(".harmony/output/reports/1001-1-studio-apply-audit.md"),
+            "# Harmony Studio Apply Audit\n\n- timestamp_unix_ms: 1001\n- status: applied\n- attempted_files: 1\n- applied_files: 1\n- rolled_back_files: 0\n- summary: Applied 1 staged edits.\n\n## Staged Edits\n- update | .harmony/orchestration/workflows/alpha/WORKFLOW.md | Normalize WORKFLOW.md frontmatter defaults\n",
+        );
+        write_file(
+            &root.join(".harmony/output/reports/1002-1-studio-apply-audit.md"),
+            "# Harmony Studio Apply Audit\n\n- timestamp_unix_ms: 1002\n- status: failed-rolled-back\n- attempted_files: 2\n- applied_files: 1\n- rolled_back_files: 1\n- summary: Apply failed and rolled back 1 file(s): synthetic write error\n\n## Staged Edits\n- create | .harmony/orchestration/workflows/beta/01-beta.md | Create missing step file\n",
+        );
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("parent directory should be created");
+        }
+        fs::write(path, contents).expect("fixture file should be written");
+    }
+}

--- a/.harmony/runtime/crates/studio/src/graph/layout.rs
+++ b/.harmony/runtime/crates/studio/src/graph/layout.rs
@@ -1,0 +1,90 @@
+use std::collections::{HashMap, VecDeque};
+
+#[derive(Debug, Clone)]
+pub struct Node {
+    pub id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Edge {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PositionedNode {
+    pub id: String,
+    pub x: f32,
+    pub y: f32,
+}
+
+pub fn layered_layout(nodes: &[Node], edges: &[Edge]) -> Vec<PositionedNode> {
+    const X_START: f32 = 80.0;
+    const Y_START: f32 = 110.0;
+    const X_STEP: f32 = 260.0;
+    const Y_STEP: f32 = 86.0;
+
+    let mut index_by_id: HashMap<&str, usize> = HashMap::new();
+    for (index, node) in nodes.iter().enumerate() {
+        index_by_id.insert(node.id.as_str(), index);
+    }
+
+    let mut indegree = vec![0usize; nodes.len()];
+    let mut outgoing = vec![Vec::<usize>::new(); nodes.len()];
+
+    for edge in edges {
+        let Some(&from_index) = index_by_id.get(edge.from.as_str()) else {
+            continue;
+        };
+        let Some(&to_index) = index_by_id.get(edge.to.as_str()) else {
+            continue;
+        };
+        outgoing[from_index].push(to_index);
+        indegree[to_index] += 1;
+    }
+
+    let mut queue = VecDeque::new();
+    let mut level = vec![0usize; nodes.len()];
+    for (index, degree) in indegree.iter().enumerate() {
+        if *degree == 0 {
+            queue.push_back(index);
+        }
+    }
+
+    while let Some(current) = queue.pop_front() {
+        let next_level = level[current] + 1;
+        for &neighbor in &outgoing[current] {
+            if level[neighbor] < next_level {
+                level[neighbor] = next_level;
+            }
+            indegree[neighbor] -= 1;
+            if indegree[neighbor] == 0 {
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    // Cycles are valid in exploratory workflow graphs; place unresolved nodes in a fallback band.
+    let fallback_level = level.iter().copied().max().unwrap_or(0) + 1;
+    for (index, degree) in indegree.iter().enumerate() {
+        if *degree > 0 {
+            level[index] = fallback_level;
+        }
+    }
+
+    let mut lane_counts: HashMap<usize, usize> = HashMap::new();
+    let mut positioned = Vec::with_capacity(nodes.len());
+    for (index, node) in nodes.iter().enumerate() {
+        let lane = lane_counts.entry(level[index]).or_insert(0);
+        let x = X_START + level[index] as f32 * X_STEP;
+        let y = Y_START + *lane as f32 * Y_STEP;
+        *lane += 1;
+        positioned.push(PositionedNode {
+            id: node.id.clone(),
+            x,
+            y,
+        });
+    }
+
+    positioned
+}

--- a/.harmony/runtime/crates/studio/src/graph/mod.rs
+++ b/.harmony/runtime/crates/studio/src/graph/mod.rs
@@ -1,0 +1,1 @@
+pub mod layout;

--- a/.harmony/runtime/crates/studio/src/main.rs
+++ b/.harmony/runtime/crates/studio/src/main.rs
@@ -1,0 +1,279 @@
+mod app_state;
+mod graph;
+mod staging;
+mod workflows;
+
+use anyhow::{Context, Result};
+use app_state::AppState;
+use slint::{ModelRc, VecModel};
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+slint::include_modules!();
+
+fn main() -> Result<()> {
+    let launch_dir = std::env::current_dir().context("failed to read current working directory")?;
+    let root = find_harmony_root(&launch_dir).unwrap_or(launch_dir);
+    let state = Rc::new(RefCell::new(AppState::load(root)?));
+
+    let window = AppWindow::new().context("failed to create Slint window")?;
+    refresh_view(&window, &state.borrow());
+
+    let weak_window = window.as_weak();
+    let state_for_select = Rc::clone(&state);
+    window.on_select_workflow(move |id| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_select.borrow_mut();
+            state.select_workflow(id.as_str());
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_pan = Rc::clone(&state);
+    window.on_pan_view(move |dx, dy| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_pan.borrow_mut();
+            state.pan_by(dx as f32, dy as f32);
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_zoom = Rc::clone(&state);
+    window.on_zoom_view(move |factor| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_zoom.borrow_mut();
+            state.zoom_by(factor);
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_reset = Rc::clone(&state);
+    window.on_reset_view(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_reset.borrow_mut();
+            state.reset_view();
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_stage = Rc::clone(&state);
+    window.on_stage_selected_edits(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_stage.borrow_mut();
+            if let Err(error) = state.stage_selected_safe_edits() {
+                eprintln!("failed to stage safe edits: {error:#}");
+            }
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_clear = Rc::clone(&state);
+    window.on_clear_staged_edits(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_clear.borrow_mut();
+            state.clear_staged_edits();
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_export = Rc::clone(&state);
+    window.on_export_patch_preview(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_export.borrow_mut();
+            if let Err(error) = state.export_patch_preview() {
+                eprintln!("failed to export patch preview: {error:#}");
+            }
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_toggle_arm = Rc::clone(&state);
+    window.on_toggle_apply_arm(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_toggle_arm.borrow_mut();
+            state.toggle_apply_arm();
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_apply = Rc::clone(&state);
+    window.on_apply_staged_edits(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_apply.borrow_mut();
+            if let Err(error) = state.apply_staged_edits() {
+                eprintln!("failed to apply staged edits: {error:#}");
+            }
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_refresh_audits = Rc::clone(&state);
+    window.on_refresh_audits(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_refresh_audits.borrow_mut();
+            state.refresh_audit_index();
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_select_audit = Rc::clone(&state);
+    window.on_select_audit(move |index| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_select_audit.borrow_mut();
+            state.select_audit(index);
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_open_audit = Rc::clone(&state);
+    window.on_open_selected_audit(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_open_audit.borrow_mut();
+            if let Err(error) = state.open_selected_audit_location() {
+                eprintln!("failed to open selected audit location: {error:#}");
+            }
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_copy_audit_path = Rc::clone(&state);
+    window.on_copy_selected_audit_path(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_copy_audit_path.borrow_mut();
+            if let Err(error) = state.copy_selected_audit_path() {
+                eprintln!("failed to copy selected audit path: {error:#}");
+            }
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_set_audit_filter_query = Rc::clone(&state);
+    window.on_set_audit_filter_query(move |query| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_set_audit_filter_query.borrow_mut();
+            state.set_audit_filter_query(query.as_str());
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_set_audit_status_filter = Rc::clone(&state);
+    window.on_set_audit_status_filter(move |mode| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_set_audit_status_filter.borrow_mut();
+            state.set_audit_status_filter(mode);
+            refresh_view(&window, &state);
+        }
+    });
+
+    window.run().context("studio window exited with error")
+}
+
+fn refresh_view(window: &AppWindow, state: &AppState) {
+    window.set_root_path(state.root_display().into());
+    window.set_status_text(state.status_line().into());
+    window.set_workflow_count(state.workflow_count() as i32);
+    window.set_edge_count(state.edge_count() as i32);
+    window.set_issue_count(state.issue_count() as i32);
+    window.set_zoom_percent(state.zoom_percent());
+    window.set_staged_edit_count(state.staged_edit_count() as i32);
+    window.set_apply_armed(state.apply_armed());
+    window.set_audit_count(state.audit_count() as i32);
+    window.set_patch_preview(state.patch_preview_text().into());
+    window.set_export_status(state.export_status_text().into());
+    window.set_selected_audit_path(state.selected_audit_path_text().into());
+    window.set_selected_audit_preview(state.selected_audit_preview_text().into());
+    window.set_audit_filter_query(state.audit_filter_query_text().into());
+    window.set_audit_status_filter_mode(state.audit_status_filter_mode());
+
+    window.set_selected_title(state.selected_title().into());
+    window.set_selected_description(state.selected_description().into());
+    window.set_selected_path(state.selected_path().into());
+    window.set_selected_dependency_summary(state.selected_dependency_summary().into());
+    window.set_selected_issue_count(state.selected_issue_count() as i32);
+
+    let workflows: Vec<WorkflowListItem> = state
+        .workflow_list_items()
+        .into_iter()
+        .map(|item| WorkflowListItem {
+            id: item.id.into(),
+            label: item.label.into(),
+            selected: item.selected,
+            issue_count: item.issue_count,
+            step_count: item.step_count,
+        })
+        .collect();
+    window.set_workflows(ModelRc::new(VecModel::from(workflows)));
+
+    let nodes: Vec<GraphNodeItem> = state
+        .graph_node_items()
+        .into_iter()
+        .map(|node| GraphNodeItem {
+            id: node.id.into(),
+            label: node.label.into(),
+            x: node.x,
+            y: node.y,
+            selected: node.selected,
+        })
+        .collect();
+    window.set_graph_nodes(ModelRc::new(VecModel::from(nodes)));
+
+    let steps: Vec<InspectorStepItem> = state
+        .selected_steps()
+        .into_iter()
+        .map(|step| InspectorStepItem {
+            id: step.id.into(),
+            file: step.file.into(),
+            status: step.status.into(),
+            description: step.description.into(),
+        })
+        .collect();
+    window.set_inspector_steps(ModelRc::new(VecModel::from(steps)));
+
+    let issues: Vec<InspectorIssueItem> = state
+        .selected_issues()
+        .into_iter()
+        .map(|issue| InspectorIssueItem {
+            code: issue.code.into(),
+            message: issue.message.into(),
+        })
+        .collect();
+    window.set_inspector_issues(ModelRc::new(VecModel::from(issues)));
+
+    let audits: Vec<ApplyAuditItem> = state
+        .audit_items()
+        .into_iter()
+        .map(|audit| ApplyAuditItem {
+            path: audit.path.into(),
+            status: audit.status.into(),
+            summary: audit.summary.into(),
+            selected: audit.selected,
+        })
+        .collect();
+    window.set_apply_audits(ModelRc::new(VecModel::from(audits)));
+}
+
+fn find_harmony_root(start: &Path) -> Option<PathBuf> {
+    start.ancestors().find_map(|ancestor| {
+        let manifest = ancestor.join(".harmony/orchestration/workflows/manifest.yml");
+        if manifest.exists() {
+            Some(ancestor.to_path_buf())
+        } else {
+            None
+        }
+    })
+}

--- a/.harmony/runtime/crates/studio/src/staging.rs
+++ b/.harmony/runtime/crates/studio/src/staging.rs
@@ -1,0 +1,772 @@
+use anyhow::{anyhow, Result};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub enum StagedFileEdit {
+    Update {
+        path: PathBuf,
+        before: String,
+        after: String,
+        reason: String,
+    },
+    Create {
+        path: PathBuf,
+        after: String,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StagedEditBuffer {
+    edits: BTreeMap<PathBuf, StagedFileEdit>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApplyReport {
+    pub attempted_files: usize,
+    pub applied_files: usize,
+    pub rolled_back_files: usize,
+    pub audit_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApplyAuditSummary {
+    pub path: PathBuf,
+    pub timestamp_unix_ms: Option<u128>,
+    pub status: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApplyStatus {
+    NoEdits,
+    Applied,
+    PreflightFailed,
+    RolledBack,
+    RollbackFailed,
+}
+
+#[derive(Debug, Clone)]
+struct ApplyExecution {
+    status: ApplyStatus,
+    attempted_files: usize,
+    applied_files: usize,
+    rolled_back_files: usize,
+    error: Option<String>,
+    rollback_error: Option<String>,
+}
+
+impl ApplyExecution {
+    fn success(attempted_files: usize) -> Self {
+        Self {
+            status: ApplyStatus::Applied,
+            attempted_files,
+            applied_files: attempted_files,
+            rolled_back_files: 0,
+            error: None,
+            rollback_error: None,
+        }
+    }
+
+    fn no_edits() -> Self {
+        Self {
+            status: ApplyStatus::NoEdits,
+            attempted_files: 0,
+            applied_files: 0,
+            rolled_back_files: 0,
+            error: None,
+            rollback_error: None,
+        }
+    }
+
+    fn preflight_failed(attempted_files: usize, error: String) -> Self {
+        Self {
+            status: ApplyStatus::PreflightFailed,
+            attempted_files,
+            applied_files: 0,
+            rolled_back_files: 0,
+            error: Some(error),
+            rollback_error: None,
+        }
+    }
+
+    fn rolled_back(attempted_files: usize, applied_files: usize, error: String) -> Self {
+        Self {
+            status: ApplyStatus::RolledBack,
+            attempted_files,
+            applied_files,
+            rolled_back_files: applied_files,
+            error: Some(error),
+            rollback_error: None,
+        }
+    }
+
+    fn rollback_failed(
+        attempted_files: usize,
+        applied_files: usize,
+        error: String,
+        rollback_error: String,
+    ) -> Self {
+        Self {
+            status: ApplyStatus::RollbackFailed,
+            attempted_files,
+            applied_files,
+            rolled_back_files: 0,
+            error: Some(error),
+            rollback_error: Some(rollback_error),
+        }
+    }
+
+    fn is_success(&self) -> bool {
+        matches!(self.status, ApplyStatus::NoEdits | ApplyStatus::Applied)
+    }
+
+    fn status_label(&self) -> &'static str {
+        match self.status {
+            ApplyStatus::NoEdits => "no-edits",
+            ApplyStatus::Applied => "applied",
+            ApplyStatus::PreflightFailed => "preflight-failed",
+            ApplyStatus::RolledBack => "failed-rolled-back",
+            ApplyStatus::RollbackFailed => "failed-rollback-error",
+        }
+    }
+
+    fn summary_line(&self) -> String {
+        match self.status {
+            ApplyStatus::NoEdits => "No staged edits to apply.".to_string(),
+            ApplyStatus::Applied => format!("Applied {} staged edits.", self.applied_files),
+            ApplyStatus::PreflightFailed => format!(
+                "Preflight failed before apply: {}",
+                self.error.as_deref().unwrap_or("unknown preflight failure")
+            ),
+            ApplyStatus::RolledBack => format!(
+                "Apply failed and rolled back {} file(s): {}",
+                self.rolled_back_files,
+                self.error.as_deref().unwrap_or("unknown write failure")
+            ),
+            ApplyStatus::RollbackFailed => format!(
+                "Apply failed and rollback also failed: {}; rollback error: {}",
+                self.error.as_deref().unwrap_or("unknown write failure"),
+                self.rollback_error
+                    .as_deref()
+                    .unwrap_or("unknown rollback failure")
+            ),
+        }
+    }
+}
+
+impl StagedEditBuffer {
+    pub fn stage_update(&mut self, path: PathBuf, before: String, after: String, reason: String) {
+        if before == after {
+            return;
+        }
+        self.edits.insert(
+            path.clone(),
+            StagedFileEdit::Update {
+                path,
+                before,
+                after,
+                reason,
+            },
+        );
+    }
+
+    pub fn stage_create(&mut self, path: PathBuf, after: String, reason: String) {
+        self.edits.insert(
+            path.clone(),
+            StagedFileEdit::Create {
+                path,
+                after,
+                reason,
+            },
+        );
+    }
+
+    pub fn clear(&mut self) {
+        self.edits.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.edits.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.edits.is_empty()
+    }
+
+    pub fn render_unified_patch(&self, repo_root: &Path) -> String {
+        if self.edits.is_empty() {
+            return "# No staged edits.\n".to_string();
+        }
+
+        let mut out = String::new();
+        for edit in self.edits.values() {
+            match edit {
+                StagedFileEdit::Update {
+                    path,
+                    before,
+                    after,
+                    reason,
+                } => {
+                    let rel = to_rel_display(repo_root, path);
+                    out.push_str(&format!("# reason: {reason}\n"));
+                    out.push_str(&format!("diff --git a/{rel} b/{rel}\n"));
+                    out.push_str(&format!("--- a/{rel}\n"));
+                    out.push_str(&format!("+++ b/{rel}\n"));
+                    out.push_str(&render_replacement_hunk(before, after));
+                }
+                StagedFileEdit::Create {
+                    path,
+                    after,
+                    reason,
+                } => {
+                    let rel = to_rel_display(repo_root, path);
+                    out.push_str(&format!("# reason: {reason}\n"));
+                    out.push_str(&format!("diff --git a/{rel} b/{rel}\n"));
+                    out.push_str("--- /dev/null\n");
+                    out.push_str(&format!("+++ b/{rel}\n"));
+                    out.push_str(&render_creation_hunk(after));
+                }
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    pub fn export_patch_preview(&self, repo_root: &Path) -> Result<PathBuf> {
+        let preview = self.render_unified_patch(repo_root);
+        let reports_dir = repo_root.join(".harmony/output/reports");
+        fs::create_dir_all(&reports_dir)?;
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| anyhow!("system clock error: {e}"))?
+            .as_millis();
+        let path = reports_dir.join(format!("{timestamp}-studio-patch-preview.diff"));
+        fs::write(&path, preview)?;
+        Ok(path)
+    }
+
+    pub fn apply_to_disk(&self, repo_root: &Path) -> Result<ApplyReport> {
+        let execution = self.execute_apply();
+        let audit_path = write_apply_audit(repo_root, &execution, &self.edits)?;
+
+        if execution.is_success() {
+            return Ok(ApplyReport {
+                attempted_files: execution.attempted_files,
+                applied_files: execution.applied_files,
+                rolled_back_files: execution.rolled_back_files,
+                audit_path,
+            });
+        }
+
+        Err(anyhow!(
+            "{} (audit artifact: {})",
+            execution.summary_line(),
+            audit_path.display()
+        ))
+    }
+
+    fn execute_apply(&self) -> ApplyExecution {
+        if self.edits.is_empty() {
+            return ApplyExecution::no_edits();
+        }
+
+        let attempted_files = self.edits.len();
+        if let Err(error) = preflight_validate(&self.edits) {
+            return ApplyExecution::preflight_failed(attempted_files, error.to_string());
+        }
+
+        let mut applied = Vec::new();
+        for edit in self.edits.values() {
+            match write_single_edit(edit) {
+                Ok(applied_edit) => applied.push(applied_edit),
+                Err(error) => {
+                    let applied_files = applied.len();
+                    return match rollback_applied_edits(&applied) {
+                        Ok(()) => ApplyExecution::rolled_back(
+                            attempted_files,
+                            applied_files,
+                            error.to_string(),
+                        ),
+                        Err(rollback_error) => ApplyExecution::rollback_failed(
+                            attempted_files,
+                            applied_files,
+                            error.to_string(),
+                            rollback_error.to_string(),
+                        ),
+                    };
+                }
+            }
+        }
+
+        ApplyExecution::success(attempted_files)
+    }
+}
+
+pub fn list_recent_apply_audits(repo_root: &Path, limit: usize) -> Result<Vec<ApplyAuditSummary>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let reports_dir = repo_root.join(".harmony/output/reports");
+    if !reports_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(&reports_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !file_name.ends_with("-studio-apply-audit.md") {
+            continue;
+        }
+
+        let timestamp_unix_ms = extract_timestamp_from_audit_file_name(file_name);
+        entries.push((timestamp_unix_ms, path));
+    }
+
+    entries.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| right.1.cmp(&left.1)));
+
+    let mut audits = Vec::new();
+    for (_, path) in entries.into_iter().take(limit) {
+        let markdown = fs::read_to_string(&path)?;
+        let parsed = parse_apply_audit_markdown(&markdown);
+        audits.push(ApplyAuditSummary {
+            path,
+            timestamp_unix_ms: parsed.timestamp_unix_ms,
+            status: parsed.status,
+            summary: parsed.summary,
+        });
+    }
+
+    Ok(audits)
+}
+
+#[derive(Debug)]
+enum AppliedEdit {
+    Updated {
+        path: PathBuf,
+        previous_contents: String,
+    },
+    Created {
+        path: PathBuf,
+    },
+}
+
+fn rollback_applied_edits(applied: &[AppliedEdit]) -> Result<()> {
+    for edit in applied.iter().rev() {
+        match edit {
+            AppliedEdit::Updated {
+                path,
+                previous_contents,
+            } => {
+                fs::write(path, previous_contents).map_err(|error| {
+                    anyhow!(
+                        "failed to rollback updated file {}: {error}",
+                        path.display()
+                    )
+                })?;
+            }
+            AppliedEdit::Created { path } => match fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(anyhow!(
+                        "failed to rollback created file {}: {error}",
+                        path.display()
+                    ));
+                }
+            },
+        }
+    }
+    Ok(())
+}
+
+fn write_single_edit(edit: &StagedFileEdit) -> Result<AppliedEdit> {
+    match edit {
+        StagedFileEdit::Update {
+            path,
+            before,
+            after,
+            ..
+        } => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).map_err(|error| {
+                    anyhow!(
+                        "failed preparing parent directory {}: {error}",
+                        parent.display()
+                    )
+                })?;
+            }
+            fs::write(path, after).map_err(|error| {
+                anyhow!(
+                    "failed writing staged update target {}: {error}",
+                    path.display()
+                )
+            })?;
+            Ok(AppliedEdit::Updated {
+                path: path.clone(),
+                previous_contents: before.clone(),
+            })
+        }
+        StagedFileEdit::Create { path, after, .. } => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).map_err(|error| {
+                    anyhow!(
+                        "failed preparing parent directory {}: {error}",
+                        parent.display()
+                    )
+                })?;
+            }
+            fs::write(path, after).map_err(|error| {
+                anyhow!(
+                    "failed writing staged create target {}: {error}",
+                    path.display()
+                )
+            })?;
+            Ok(AppliedEdit::Created { path: path.clone() })
+        }
+    }
+}
+
+fn preflight_validate(edits: &BTreeMap<PathBuf, StagedFileEdit>) -> Result<()> {
+    for edit in edits.values() {
+        match edit {
+            StagedFileEdit::Update { path, before, .. } => {
+                if !path.exists() {
+                    return Err(anyhow!(
+                        "staged update target does not exist: {}",
+                        path.display()
+                    ));
+                }
+
+                let current = fs::read_to_string(path).map_err(|error| {
+                    anyhow!(
+                        "failed to read staged update target {}: {error}",
+                        path.display()
+                    )
+                })?;
+                if current != *before {
+                    return Err(anyhow!(
+                        "staged update conflict at {}: file changed since staging",
+                        path.display()
+                    ));
+                }
+            }
+            StagedFileEdit::Create { path, .. } => {
+                if path.exists() {
+                    return Err(anyhow!(
+                        "staged create target already exists: {}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_apply_audit(
+    repo_root: &Path,
+    execution: &ApplyExecution,
+    edits: &BTreeMap<PathBuf, StagedFileEdit>,
+) -> Result<PathBuf> {
+    let reports_dir = repo_root.join(".harmony/output/reports");
+    match write_apply_audit_in_dir(&reports_dir, repo_root, execution, edits) {
+        Ok(path) => Ok(path),
+        Err(primary_error) => {
+            let fallback_dir = std::env::temp_dir().join("harmony-studio-reports");
+            write_apply_audit_in_dir(&fallback_dir, repo_root, execution, edits).map_err(
+                |fallback_error| {
+                    anyhow!(
+                        "failed to write apply audit artifact in {}: {primary_error}; fallback {} also failed: {fallback_error}",
+                        reports_dir.display(),
+                        fallback_dir.display()
+                    )
+                },
+            )
+        }
+    }
+}
+
+fn write_apply_audit_in_dir(
+    reports_dir: &Path,
+    repo_root: &Path,
+    execution: &ApplyExecution,
+    edits: &BTreeMap<PathBuf, StagedFileEdit>,
+) -> Result<PathBuf> {
+    fs::create_dir_all(reports_dir)?;
+
+    let timestamp_unix_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| anyhow!("system clock error: {e}"))?
+        .as_millis();
+    let pid = std::process::id();
+    let path = reports_dir.join(format!("{timestamp_unix_ms}-{pid}-studio-apply-audit.md"));
+    let markdown = render_apply_audit_markdown(timestamp_unix_ms, repo_root, execution, edits);
+    fs::write(&path, markdown)?;
+    Ok(path)
+}
+
+fn render_apply_audit_markdown(
+    timestamp_unix_ms: u128,
+    repo_root: &Path,
+    execution: &ApplyExecution,
+    edits: &BTreeMap<PathBuf, StagedFileEdit>,
+) -> String {
+    let mut out = String::new();
+    out.push_str("# Harmony Studio Apply Audit\n\n");
+    out.push_str(&format!("- timestamp_unix_ms: {timestamp_unix_ms}\n"));
+    out.push_str(&format!("- status: {}\n", execution.status_label()));
+    out.push_str(&format!(
+        "- attempted_files: {}\n",
+        execution.attempted_files
+    ));
+    out.push_str(&format!("- applied_files: {}\n", execution.applied_files));
+    out.push_str(&format!(
+        "- rolled_back_files: {}\n",
+        execution.rolled_back_files
+    ));
+    out.push_str(&format!("- summary: {}\n", execution.summary_line()));
+    if let Some(error) = &execution.error {
+        out.push_str(&format!("- error: {error}\n"));
+    }
+    if let Some(error) = &execution.rollback_error {
+        out.push_str(&format!("- rollback_error: {error}\n"));
+    }
+
+    out.push_str("\n## Staged Edits\n");
+    if edits.is_empty() {
+        out.push_str("- none\n");
+        return out;
+    }
+
+    for edit in edits.values() {
+        match edit {
+            StagedFileEdit::Update { path, reason, .. } => {
+                out.push_str(&format!(
+                    "- update | {} | {reason}\n",
+                    to_rel_display(repo_root, path)
+                ));
+            }
+            StagedFileEdit::Create { path, reason, .. } => {
+                out.push_str(&format!(
+                    "- create | {} | {reason}\n",
+                    to_rel_display(repo_root, path)
+                ));
+            }
+        }
+    }
+
+    out
+}
+
+#[derive(Debug, Clone)]
+struct ParsedApplyAudit {
+    timestamp_unix_ms: Option<u128>,
+    status: String,
+    summary: String,
+}
+
+fn parse_apply_audit_markdown(markdown: &str) -> ParsedApplyAudit {
+    let mut timestamp_unix_ms = None;
+    let mut status = String::from("unknown");
+    let mut summary = String::from("No summary captured.");
+
+    for line in markdown.lines() {
+        if let Some(value) = line.strip_prefix("- timestamp_unix_ms: ") {
+            timestamp_unix_ms = value.trim().parse::<u128>().ok();
+        } else if let Some(value) = line.strip_prefix("- status: ") {
+            status = value.trim().to_string();
+        } else if let Some(value) = line.strip_prefix("- summary: ") {
+            summary = value.trim().to_string();
+        }
+    }
+
+    ParsedApplyAudit {
+        timestamp_unix_ms,
+        status,
+        summary,
+    }
+}
+
+fn extract_timestamp_from_audit_file_name(file_name: &str) -> Option<u128> {
+    let mut segments = file_name.splitn(2, '-');
+    let timestamp = segments.next()?;
+    timestamp.parse::<u128>().ok()
+}
+
+fn to_rel_display(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn render_replacement_hunk(before: &str, after: &str) -> String {
+    let old_lines: Vec<&str> = before.lines().collect();
+    let new_lines: Vec<&str> = after.lines().collect();
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "@@ -1,{} +1,{} @@\n",
+        old_lines.len(),
+        new_lines.len()
+    ));
+    for line in old_lines {
+        out.push('-');
+        out.push_str(line);
+        out.push('\n');
+    }
+    for line in new_lines {
+        out.push('+');
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+fn render_creation_hunk(after: &str) -> String {
+    let lines: Vec<&str> = after.lines().collect();
+    let mut out = String::new();
+    out.push_str(&format!("@@ -0,0 +1,{} @@\n", lines.len()));
+    for line in lines {
+        out.push('+');
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StagedEditBuffer;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be valid")
+            .as_nanos();
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("harmony-studio-{label}-{pid}-{stamp}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    fn extract_audit_path(message: &str) -> Option<PathBuf> {
+        let marker = "audit artifact: ";
+        let index = message.find(marker)?;
+        let path = &message[(index + marker.len())..];
+        Some(PathBuf::from(path.trim_end_matches(')')))
+    }
+
+    #[test]
+    fn apply_to_disk_writes_update_and_create() {
+        let root = temp_dir("apply-ok");
+        let existing_path = root.join("01-existing.txt");
+        fs::write(&existing_path, "before\n").expect("existing file should be written");
+
+        let create_path = root.join("02-created.txt");
+
+        let mut buffer = StagedEditBuffer::default();
+        buffer.stage_update(
+            existing_path.clone(),
+            "before\n".to_string(),
+            "after\n".to_string(),
+            "update existing".to_string(),
+        );
+        buffer.stage_create(
+            create_path.clone(),
+            "new file\n".to_string(),
+            "create file".to_string(),
+        );
+
+        let report = buffer.apply_to_disk(&root).expect("apply should succeed");
+        assert_eq!(report.attempted_files, 2);
+        assert_eq!(report.applied_files, 2);
+        assert_eq!(report.rolled_back_files, 0);
+        assert_eq!(
+            fs::read_to_string(existing_path).expect("updated file should exist"),
+            "after\n"
+        );
+        assert_eq!(
+            fs::read_to_string(create_path).expect("created file should exist"),
+            "new file\n"
+        );
+        assert!(report.audit_path.exists(), "audit artifact should exist");
+        let audit_markdown =
+            fs::read_to_string(&report.audit_path).expect("audit artifact should be readable");
+        assert!(
+            audit_markdown.contains("- status: applied"),
+            "audit should contain applied status"
+        );
+
+        fs::remove_dir_all(root).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn apply_to_disk_rolls_back_after_late_write_failure() {
+        let root = temp_dir("apply-rollback");
+        let update_path = root.join("01-update-target.txt");
+        fs::write(&update_path, "original\n").expect("update target should be written");
+
+        let blocked_parent = root.join("02-blocked-parent");
+        fs::write(&blocked_parent, "not a directory\n").expect("blocked parent should be file");
+        let create_path = blocked_parent.join("child.txt");
+
+        let mut buffer = StagedEditBuffer::default();
+        buffer.stage_update(
+            update_path.clone(),
+            "original\n".to_string(),
+            "changed\n".to_string(),
+            "update first".to_string(),
+        );
+        buffer.stage_create(
+            create_path.clone(),
+            "created\n".to_string(),
+            "create second".to_string(),
+        );
+
+        let error = buffer.apply_to_disk(&root).expect_err("apply should fail");
+        let message = format!("{error}");
+        assert!(
+            message.contains("rolled back"),
+            "error should report rollback, got: {message}"
+        );
+        let audit_path = extract_audit_path(&message).expect("audit path should be present");
+        assert!(
+            audit_path.exists(),
+            "audit artifact should exist on failure"
+        );
+        let audit_markdown =
+            fs::read_to_string(&audit_path).expect("failure audit should be readable");
+        assert!(
+            audit_markdown.contains("- status: failed-rolled-back"),
+            "audit should capture rollback status"
+        );
+        assert_eq!(
+            fs::read_to_string(&update_path).expect("updated file should still exist"),
+            "original\n",
+            "updated file should be restored after rollback"
+        );
+        assert!(
+            !create_path.exists(),
+            "failed create target should not exist after rollback"
+        );
+
+        fs::remove_dir_all(root).expect("temp dir should be removed");
+    }
+}

--- a/.harmony/runtime/crates/studio/src/workflows/load.rs
+++ b/.harmony/runtime/crates/studio/src/workflows/load.rs
@@ -1,0 +1,277 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct WorkflowSummary {
+    pub id: String,
+    pub manifest_path_hint: Option<String>,
+    pub registry_path_hint: Option<String>,
+    pub workflow_dir: PathBuf,
+    pub workflow_file: PathBuf,
+    pub has_workflow_file: bool,
+    pub dependencies: Vec<String>,
+    pub document: Option<WorkflowDocument>,
+    pub parse_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowDocument {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub steps: Vec<WorkflowStepSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowStepSummary {
+    pub id: String,
+    pub file: String,
+    pub description: Option<String>,
+    pub path: PathBuf,
+    pub exists: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowIndexSnapshot {
+    pub manifest_path: PathBuf,
+    pub registry_path: PathBuf,
+    pub workflows: Vec<WorkflowSummary>,
+    pub registry_ids: BTreeSet<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestFile {
+    #[serde(default)]
+    workflows: Vec<ManifestWorkflow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestWorkflow {
+    id: String,
+    path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryFile {
+    #[serde(default)]
+    workflows: BTreeMap<String, RegistryWorkflow>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RegistryWorkflow {
+    path: Option<String>,
+    #[serde(default)]
+    depends_on: Vec<RegistryDependency>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RegistryDependency {
+    workflow: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct WorkflowFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    #[serde(default)]
+    steps: Vec<WorkflowStepFrontmatter>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowStepFrontmatter {
+    id: String,
+    file: String,
+    description: Option<String>,
+}
+
+pub fn load_workflow_index(root: &Path) -> Result<WorkflowIndexSnapshot> {
+    let workflows_root = root.join(".harmony/orchestration/workflows");
+    let manifest_path = workflows_root.join("manifest.yml");
+    let registry_path = workflows_root.join("registry.yml");
+
+    let manifest_raw = fs::read_to_string(&manifest_path).with_context(|| {
+        format!(
+            "failed to read workflow manifest at {}",
+            manifest_path.display()
+        )
+    })?;
+    let registry_raw = fs::read_to_string(&registry_path).with_context(|| {
+        format!(
+            "failed to read workflow registry at {}",
+            registry_path.display()
+        )
+    })?;
+
+    let manifest: ManifestFile = serde_yaml::from_str(&manifest_raw)
+        .with_context(|| format!("failed to parse {}", manifest_path.display()))?;
+    let registry: RegistryFile = serde_yaml::from_str(&registry_raw)
+        .with_context(|| format!("failed to parse {}", registry_path.display()))?;
+
+    let registry_ids = registry.workflows.keys().cloned().collect();
+    let mut workflows: Vec<WorkflowSummary> = manifest
+        .workflows
+        .into_iter()
+        .map(|workflow| {
+            let registry_entry = registry.workflows.get(&workflow.id);
+            let registry_path_hint = registry_entry.and_then(|entry| entry.path.clone());
+            let workflow_dir = resolve_workflow_dir(
+                &workflows_root,
+                &workflow.id,
+                workflow.path.as_deref(),
+                registry_path_hint.as_deref(),
+            );
+            let workflow_file = workflow_dir.join("WORKFLOW.md");
+            let dependencies = registry_entry
+                .map(|entry| {
+                    entry
+                        .depends_on
+                        .iter()
+                        .filter_map(|dependency| dependency.workflow.as_deref())
+                        .map(normalize_workflow_reference)
+                        .filter(|reference| !reference.is_empty())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let (document, parse_error) = parse_workflow_document(&workflow_dir, &workflow_file);
+            WorkflowSummary {
+                id: workflow.id,
+                manifest_path_hint: workflow.path,
+                registry_path_hint,
+                has_workflow_file: workflow_file.exists(),
+                workflow_file,
+                workflow_dir,
+                dependencies,
+                document,
+                parse_error,
+            }
+        })
+        .collect();
+    workflows.sort_by(|left, right| left.id.cmp(&right.id));
+
+    Ok(WorkflowIndexSnapshot {
+        manifest_path,
+        registry_path,
+        workflows,
+        registry_ids,
+    })
+}
+
+fn resolve_workflow_dir(
+    workflows_root: &Path,
+    id: &str,
+    manifest_path: Option<&str>,
+    registry_path: Option<&str>,
+) -> PathBuf {
+    if let Some(path_hint) = manifest_path {
+        let normalized = path_hint.trim().trim_end_matches('/');
+        if !normalized.is_empty() {
+            return workflows_root.join(normalized);
+        }
+    }
+
+    if let Some(path_hint) = registry_path {
+        let normalized = path_hint.trim().trim_end_matches('/');
+        if !normalized.is_empty() {
+            return workflows_root.join(normalized);
+        }
+    }
+
+    workflows_root.join(id)
+}
+
+fn normalize_workflow_reference(raw: &str) -> String {
+    raw.trim()
+        .trim_matches('"')
+        .split('/')
+        .next_back()
+        .unwrap_or(raw.trim())
+        .to_string()
+}
+
+fn parse_workflow_document(
+    workflow_dir: &Path,
+    workflow_file: &Path,
+) -> (Option<WorkflowDocument>, Option<String>) {
+    if !workflow_file.exists() {
+        return (None, None);
+    }
+
+    let markdown = match fs::read_to_string(workflow_file) {
+        Ok(value) => value,
+        Err(error) => {
+            return (
+                None,
+                Some(format!(
+                    "failed to read {}: {error}",
+                    workflow_file.display()
+                )),
+            );
+        }
+    };
+
+    let Some(frontmatter_yaml) = extract_frontmatter(&markdown) else {
+        return (
+            None,
+            Some(format!(
+                "missing YAML frontmatter in {}",
+                workflow_file.display()
+            )),
+        );
+    };
+
+    let frontmatter: WorkflowFrontmatter = match serde_yaml::from_str(&frontmatter_yaml) {
+        Ok(value) => value,
+        Err(error) => {
+            return (
+                None,
+                Some(format!(
+                    "invalid frontmatter in {}: {error}",
+                    workflow_file.display()
+                )),
+            );
+        }
+    };
+
+    let steps = frontmatter
+        .steps
+        .into_iter()
+        .map(|step| {
+            let path = workflow_dir.join(&step.file);
+            WorkflowStepSummary {
+                id: step.id,
+                file: step.file,
+                description: step.description,
+                exists: path.exists(),
+                path,
+            }
+        })
+        .collect();
+
+    (
+        Some(WorkflowDocument {
+            name: frontmatter.name,
+            description: frontmatter.description,
+            steps,
+        }),
+        None,
+    )
+}
+
+fn extract_frontmatter(markdown: &str) -> Option<String> {
+    let mut lines = markdown.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+
+    let mut yaml_lines = Vec::new();
+    for line in lines {
+        if line.trim() == "---" {
+            return Some(yaml_lines.join("\n"));
+        }
+        yaml_lines.push(line);
+    }
+
+    None
+}

--- a/.harmony/runtime/crates/studio/src/workflows/mod.rs
+++ b/.harmony/runtime/crates/studio/src/workflows/mod.rs
@@ -1,0 +1,5 @@
+pub mod load;
+pub mod validate;
+
+pub use load::{load_workflow_index, WorkflowIndexSnapshot, WorkflowSummary};
+pub use validate::{validate_snapshot, ValidationIssue};

--- a/.harmony/runtime/crates/studio/src/workflows/validate.rs
+++ b/.harmony/runtime/crates/studio/src/workflows/validate.rs
@@ -1,0 +1,116 @@
+use crate::workflows::WorkflowIndexSnapshot;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct ValidationIssue {
+    pub code: &'static str,
+    pub workflow_id: Option<String>,
+    pub message: String,
+    pub path: Option<PathBuf>,
+}
+
+pub fn validate_snapshot(snapshot: &WorkflowIndexSnapshot) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    for workflow in &snapshot.workflows {
+        if !workflow.has_workflow_file {
+            issues.push(ValidationIssue {
+                code: "missing-workflow-file",
+                workflow_id: Some(workflow.id.clone()),
+                message: format!("Workflow '{}' is missing WORKFLOW.md", workflow.id),
+                path: Some(workflow.workflow_file.clone()),
+            });
+        }
+
+        if let Some(parse_error) = &workflow.parse_error {
+            issues.push(ValidationIssue {
+                code: "invalid-workflow-frontmatter",
+                workflow_id: Some(workflow.id.clone()),
+                message: format!(
+                    "Workflow '{}' frontmatter error: {parse_error}",
+                    workflow.id
+                ),
+                path: Some(workflow.workflow_file.clone()),
+            });
+        }
+
+        if let Some(document) = &workflow.document {
+            if document.steps.is_empty() {
+                issues.push(ValidationIssue {
+                    code: "missing-workflow-steps",
+                    workflow_id: Some(workflow.id.clone()),
+                    message: format!(
+                        "Workflow '{}' does not declare any step entries in frontmatter",
+                        workflow.id
+                    ),
+                    path: Some(workflow.workflow_file.clone()),
+                });
+            }
+
+            for step in &document.steps {
+                if !step.exists {
+                    issues.push(ValidationIssue {
+                        code: "missing-step-file",
+                        workflow_id: Some(workflow.id.clone()),
+                        message: format!(
+                            "Workflow '{}' step '{}' points to missing file '{}'",
+                            workflow.id, step.id, step.file
+                        ),
+                        path: Some(step.path.clone()),
+                    });
+                }
+            }
+        }
+    }
+
+    let manifest_ids: BTreeSet<String> = snapshot
+        .workflows
+        .iter()
+        .map(|workflow| workflow.id.clone())
+        .collect();
+
+    for workflow in &snapshot.workflows {
+        if !snapshot.registry_ids.contains(&workflow.id) {
+            issues.push(ValidationIssue {
+                code: "missing-registry-entry",
+                workflow_id: Some(workflow.id.clone()),
+                message: format!(
+                    "Workflow '{}' exists in manifest but not in registry",
+                    workflow.id
+                ),
+                path: Some(snapshot.registry_path.clone()),
+            });
+        }
+
+        for dependency in &workflow.dependencies {
+            if !manifest_ids.contains(dependency) {
+                issues.push(ValidationIssue {
+                    code: "unknown-workflow-dependency",
+                    workflow_id: Some(workflow.id.clone()),
+                    message: format!(
+                        "Workflow '{}' depends on missing workflow '{}'",
+                        workflow.id, dependency
+                    ),
+                    path: Some(snapshot.registry_path.clone()),
+                });
+            }
+        }
+    }
+
+    for registry_id in &snapshot.registry_ids {
+        if !manifest_ids.contains(registry_id) {
+            issues.push(ValidationIssue {
+                code: "missing-manifest-entry",
+                workflow_id: Some(registry_id.clone()),
+                message: format!(
+                    "Workflow '{}' exists in registry but not in manifest",
+                    registry_id
+                ),
+                path: Some(snapshot.manifest_path.clone()),
+            });
+        }
+    }
+
+    issues
+}

--- a/.harmony/runtime/crates/studio/ui/app.slint
+++ b/.harmony/runtime/crates/studio/ui/app.slint
@@ -1,0 +1,701 @@
+export struct WorkflowListItem {
+    id: string,
+    label: string,
+    selected: bool,
+    issue_count: int,
+    step_count: int,
+}
+
+export struct GraphNodeItem {
+    id: string,
+    label: string,
+    x: float,
+    y: float,
+    selected: bool,
+}
+
+export struct InspectorStepItem {
+    id: string,
+    file: string,
+    status: string,
+    description: string,
+}
+
+export struct InspectorIssueItem {
+    code: string,
+    message: string,
+}
+
+export struct ApplyAuditItem {
+    path: string,
+    status: string,
+    summary: string,
+    selected: bool,
+}
+
+component ActionButton inherits Rectangle {
+    in property <string> label;
+    callback clicked();
+
+    border-color: #2f4155;
+    border-width: 1px;
+    border-radius: 7px;
+    background: #1b2a38;
+
+    Text {
+        text: root.label;
+        color: #dce7f7;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+
+    TouchArea {
+        clicked => {
+            root.clicked();
+        }
+    }
+}
+
+export component AppWindow inherits Window {
+    title: "Harmony Studio";
+    width: 1340px;
+    height: 860px;
+    background: #0e141c;
+
+    in-out property <string> root_path: "Locating .harmony root...";
+    in-out property <string> status_text: "Initializing workflow index...";
+    in-out property <int> workflow_count: 0;
+    in-out property <int> edge_count: 0;
+    in-out property <int> issue_count: 0;
+    in-out property <int> zoom_percent: 100;
+    in-out property <int> staged_edit_count: 0;
+    in-out property <bool> apply_armed: false;
+    in-out property <int> audit_count: 0;
+    in-out property <string> patch_preview: "# No staged edits.\n";
+    in-out property <string> export_status: "No staged edits yet.";
+    in-out property <string> selected_audit_path: "No audit selected";
+    in-out property <string> selected_audit_preview: "# No apply audits found.\n";
+    in-out property <string> audit_filter_query: "";
+    in-out property <int> audit_status_filter_mode: 0;
+
+    in-out property <[WorkflowListItem]> workflows;
+    in-out property <[GraphNodeItem]> graph_nodes;
+    in-out property <[InspectorStepItem]> inspector_steps;
+    in-out property <[InspectorIssueItem]> inspector_issues;
+    in-out property <[ApplyAuditItem]> apply_audits;
+
+    in-out property <string> selected_title: "No workflow selected";
+    in-out property <string> selected_description: "";
+    in-out property <string> selected_path: "-";
+    in-out property <string> selected_dependency_summary: "Dependencies: -";
+    in-out property <int> selected_issue_count: 0;
+
+    callback select-workflow(string);
+    callback pan-view(int, int);
+    callback zoom-view(float);
+    callback reset-view();
+    callback stage-selected-edits();
+    callback clear-staged-edits();
+    callback export-patch-preview();
+    callback toggle-apply-arm();
+    callback apply-staged-edits();
+    callback refresh-audits();
+    callback select-audit(int);
+    callback open-selected-audit();
+    callback copy-selected-audit-path();
+    callback set-audit-filter-query(string);
+    callback set-audit-status-filter(int);
+
+    VerticalLayout {
+        spacing: 12px;
+        padding: 16px;
+
+        Rectangle {
+            border-color: #2c3a49;
+            border-width: 1px;
+            border-radius: 10px;
+            background: #111a24;
+            height: 76px;
+
+            Text {
+                text: "Harmony Studio";
+                color: #eef4ff;
+                font-size: 24px;
+                x: 14px;
+                y: 10px;
+            }
+
+            Text {
+                text: root_path;
+                color: #97a9be;
+                x: 14px;
+                y: 44px;
+            }
+        }
+
+        HorizontalLayout {
+            spacing: 12px;
+
+            Rectangle {
+                border-color: #2c3a49;
+                border-width: 1px;
+                border-radius: 10px;
+                background: #131d28;
+                horizontal-stretch: 1;
+
+                Text {
+                    text: "Workflows (" + workflow_count + ")";
+                    color: #ecf3ff;
+                    font-size: 18px;
+                    x: 14px;
+                    y: 12px;
+                }
+
+                Rectangle {
+                    x: 12px;
+                    y: 44px;
+                    width: parent.width - 24px;
+                    height: parent.height - 56px;
+                    background: #101822;
+                    border-color: #27374a;
+                    border-width: 1px;
+                    border-radius: 8px;
+
+                    for workflow[index] in root.workflows: Rectangle {
+                        x: 8px;
+                        y: 8px + index * 40px;
+                        width: parent.width - 16px;
+                        height: 34px;
+                        border-color: workflow.selected ? #5ea1ff : #2f4052;
+                        border-width: workflow.selected ? 2px : 1px;
+                        border-radius: 6px;
+                        background: workflow.selected ? #1d3146 : #172432;
+
+                        Text {
+                            text: workflow.label + " (" + workflow.step_count + " steps, " + workflow.issue_count + " issues)";
+                            color: #d9e5f5;
+                            x: 10px;
+                            y: 8px;
+                        }
+
+                        TouchArea {
+                            clicked => {
+                                root.select-workflow(workflow.id);
+                            }
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                border-color: #2c3a49;
+                border-width: 1px;
+                border-radius: 10px;
+                background: #131d28;
+                horizontal-stretch: 2;
+
+                Text {
+                    text: "Graph (" + edge_count + " dependency edges)";
+                    color: #ecf3ff;
+                    font-size: 18px;
+                    x: 14px;
+                    y: 12px;
+                }
+
+                HorizontalLayout {
+                    x: 14px;
+                    y: 44px;
+                    spacing: 8px;
+
+                    ActionButton {
+                        width: 42px;
+                        height: 30px;
+                        label: "←";
+                        clicked => { root.pan-view(80, 0); }
+                    }
+                    ActionButton {
+                        width: 42px;
+                        height: 30px;
+                        label: "→";
+                        clicked => { root.pan-view(-80, 0); }
+                    }
+                    ActionButton {
+                        width: 42px;
+                        height: 30px;
+                        label: "↑";
+                        clicked => { root.pan-view(0, 80); }
+                    }
+                    ActionButton {
+                        width: 42px;
+                        height: 30px;
+                        label: "↓";
+                        clicked => { root.pan-view(0, -80); }
+                    }
+                    ActionButton {
+                        width: 42px;
+                        height: 30px;
+                        label: "+";
+                        clicked => { root.zoom-view(1.15); }
+                    }
+                    ActionButton {
+                        width: 42px;
+                        height: 30px;
+                        label: "-";
+                        clicked => { root.zoom-view(0.87); }
+                    }
+                    ActionButton {
+                        width: 70px;
+                        height: 30px;
+                        label: "Reset";
+                        clicked => { root.reset-view(); }
+                    }
+
+                    Text {
+                        text: "zoom " + zoom_percent + "%";
+                        color: #d5e3f8;
+                        y: 6px;
+                    }
+                }
+
+                Rectangle {
+                    x: 12px;
+                    y: 82px;
+                    width: parent.width - 24px;
+                    height: parent.height - 94px;
+                    background: #0f1721;
+                    border-color: #26374a;
+                    border-width: 1px;
+                    border-radius: 8px;
+                    clip: true;
+
+                    for node[index] in root.graph_nodes: Rectangle {
+                        x: node.x * 1px;
+                        y: node.y * 1px;
+                        width: 170px;
+                        height: 52px;
+                        border-color: node.selected ? #7eb5ff : #334960;
+                        border-width: node.selected ? 2px : 1px;
+                        border-radius: 6px;
+                        background: node.selected ? #24415f : #1a2a3a;
+
+                        Text {
+                            text: node.label;
+                            color: #e8f1ff;
+                            x: 10px;
+                            y: 8px;
+                        }
+
+                        Text {
+                            text: node.id;
+                            color: #9bb0c9;
+                            x: 10px;
+                            y: 28px;
+                        }
+
+                        TouchArea {
+                            clicked => {
+                                root.select-workflow(node.id);
+                            }
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                border-color: #2c3a49;
+                border-width: 1px;
+                border-radius: 10px;
+                background: #131d28;
+                horizontal-stretch: 1;
+
+                Text {
+                    text: "Inspector (" + selected_issue_count + " issues)";
+                    color: #ecf3ff;
+                    font-size: 18px;
+                    x: 14px;
+                    y: 12px;
+                }
+
+                Text {
+                    text: selected_title;
+                    color: #dbe8fa;
+                    font-size: 16px;
+                    x: 14px;
+                    y: 44px;
+                    width: parent.width - 28px;
+                    wrap: word-wrap;
+                }
+
+                Text {
+                    text: selected_description;
+                    color: #9fb2c8;
+                    x: 14px;
+                    y: 78px;
+                    width: parent.width - 28px;
+                    wrap: word-wrap;
+                }
+
+                Text {
+                    text: selected_dependency_summary;
+                    color: #d0dff2;
+                    x: 14px;
+                    y: 134px;
+                    width: parent.width - 28px;
+                    wrap: word-wrap;
+                }
+
+                Text {
+                    text: selected_path;
+                    color: #7f96b3;
+                    x: 14px;
+                    y: 164px;
+                    width: parent.width - 28px;
+                    wrap: word-wrap;
+                }
+
+                Rectangle {
+                    x: 12px;
+                    y: 196px;
+                    width: parent.width - 24px;
+                    height: parent.height - 208px;
+                    background: #0f1721;
+                    border-color: #27374a;
+                    border-width: 1px;
+                    border-radius: 8px;
+
+                    Text {
+                        text: "Steps";
+                        color: #d5e4f8;
+                        x: 10px;
+                        y: 8px;
+                    }
+
+                    for step[index] in root.inspector_steps: Rectangle {
+                        x: 8px;
+                        y: 30px + index * 42px;
+                        width: parent.width - 16px;
+                        height: 36px;
+                        border-color: step.status == "ok" ? #335b47 : #7a4a4a;
+                        border-width: 1px;
+                        border-radius: 6px;
+                        background: step.status == "ok" ? #182a24 : #321e24;
+
+                        Text {
+                            text: step.id + " · " + step.file + " · " + step.status;
+                            color: #d8e5f7;
+                            x: 8px;
+                            y: 5px;
+                        }
+
+                        Text {
+                            text: step.description;
+                            color: #9fb2c8;
+                            x: 8px;
+                            y: 20px;
+                            width: parent.width - 16px;
+                            wrap: word-wrap;
+                        }
+                    }
+
+                    Text {
+                        text: "Issues";
+                        color: #d5e4f8;
+                        x: 10px;
+                        y: parent.height - 96px;
+                    }
+
+                    for issue[index] in root.inspector_issues: Rectangle {
+                        x: 8px;
+                        y: parent.height - 74px + index * 30px;
+                        width: parent.width - 16px;
+                        height: 24px;
+                        border-color: #7b5252;
+                        border-width: 1px;
+                        border-radius: 4px;
+                        background: #332226;
+
+                        Text {
+                            text: issue.code + ": " + issue.message;
+                            color: #f0d5d8;
+                            x: 6px;
+                            y: 4px;
+                            width: parent.width - 12px;
+                            wrap: word-wrap;
+                        }
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            border-color: #2c3a49;
+            border-width: 1px;
+            border-radius: 10px;
+            background: #111a24;
+            height: 336px;
+
+            Text {
+                text: "Apply Audits (" + audit_count + ")";
+                color: #e8f1ff;
+                font-size: 18px;
+                x: 14px;
+                y: 12px;
+            }
+
+            ActionButton {
+                x: parent.width - 226px;
+                y: 10px;
+                width: 100px;
+                height: 30px;
+                label: "Refresh";
+                clicked => { root.refresh-audits(); }
+            }
+
+            ActionButton {
+                x: parent.width - 114px;
+                y: 10px;
+                width: 100px;
+                height: 30px;
+                label: "Copy Path";
+                clicked => { root.copy-selected-audit-path(); }
+            }
+
+            Rectangle {
+                x: 12px;
+                y: 46px;
+                width: 270px;
+                height: 26px;
+                border-color: #34495d;
+                border-width: 1px;
+                border-radius: 4px;
+                background: #0f1721;
+
+                audit_query_input := TextInput {
+                    x: 6px;
+                    y: 3px;
+                    width: parent.width - 12px;
+                    height: parent.height - 6px;
+                    text: audit_filter_query;
+                    edited => {
+                        root.set-audit-filter-query(audit_query_input.text);
+                    }
+                }
+            }
+
+            ActionButton {
+                x: parent.width - 322px;
+                y: 46px;
+                width: 100px;
+                height: 26px;
+                label: "Open File";
+                clicked => { root.open-selected-audit(); }
+            }
+
+            ActionButton {
+                x: parent.width - 214px;
+                y: 46px;
+                width: 100px;
+                height: 26px;
+                label: audit_status_filter_mode == 0 ? "[All]" : "All";
+                clicked => { root.set-audit-status-filter(0); }
+            }
+
+            ActionButton {
+                x: parent.width - 106px;
+                y: 46px;
+                width: 100px;
+                height: 26px;
+                label: audit_status_filter_mode == 1 ? "[Applied]" : "Applied";
+                clicked => { root.set-audit-status-filter(1); }
+            }
+
+            ActionButton {
+                x: parent.width - 106px;
+                y: 76px;
+                width: 100px;
+                height: 26px;
+                label: audit_status_filter_mode == 2 ? "[Failed]" : "Failed";
+                clicked => { root.set-audit-status-filter(2); }
+            }
+
+            Rectangle {
+                x: 12px;
+                y: 106px;
+                width: parent.width - 24px;
+                height: 106px;
+                border-color: #27374a;
+                border-width: 1px;
+                border-radius: 8px;
+                background: #0f1721;
+                clip: true;
+
+                for audit[index] in root.apply_audits: Rectangle {
+                    x: 8px;
+                    y: 8px + index * 28px;
+                    width: parent.width - 16px;
+                    height: 24px;
+                    border-color: audit.selected ? #6ea8ff : (audit.status == "applied" ? #335b47 : #7a4a4a);
+                    border-width: 1px;
+                    border-radius: 4px;
+                    background: audit.selected ? #1f3451 : (audit.status == "applied" ? #182a24 : #321e24);
+
+                    Text {
+                        text: audit.status + " · " + audit.summary;
+                        color: #d8e5f7;
+                        x: 6px;
+                        y: 3px;
+                        width: parent.width - 12px;
+                        wrap: word-wrap;
+                    }
+
+                    TouchArea {
+                        clicked => {
+                            root.select-audit(index);
+                        }
+                    }
+                }
+            }
+
+            Text {
+                text: selected_audit_path;
+                color: #9eb6cf;
+                x: 14px;
+                y: 218px;
+                width: parent.width - 28px;
+                wrap: word-wrap;
+            }
+
+            Rectangle {
+                x: 12px;
+                y: 244px;
+                width: parent.width - 24px;
+                height: parent.height - 256px;
+                border-color: #27374a;
+                border-width: 1px;
+                border-radius: 8px;
+                background: #0f1721;
+                clip: true;
+
+                Text {
+                    text: selected_audit_preview;
+                    color: #d7e5f8;
+                    x: 10px;
+                    y: 8px;
+                    width: parent.width - 20px;
+                    wrap: word-wrap;
+                }
+            }
+        }
+
+        Rectangle {
+            border-color: #2c3a49;
+            border-width: 1px;
+            border-radius: 10px;
+            background: #111a24;
+            height: 238px;
+
+            Text {
+                text: "Staged Edit Buffer (" + staged_edit_count + " files)";
+                color: #e8f1ff;
+                font-size: 18px;
+                x: 14px;
+                y: 12px;
+            }
+
+            HorizontalLayout {
+                x: 14px;
+                y: 42px;
+                spacing: 8px;
+
+                ActionButton {
+                    width: 150px;
+                    height: 30px;
+                    label: "Stage Safe Edits";
+                    clicked => { root.stage-selected-edits(); }
+                }
+
+                ActionButton {
+                    width: 70px;
+                    height: 30px;
+                    label: "Clear";
+                    clicked => { root.clear-staged-edits(); }
+                }
+
+                ActionButton {
+                    width: 170px;
+                    height: 30px;
+                    label: "Export Patch Preview";
+                    clicked => { root.export-patch-preview(); }
+                }
+
+                ActionButton {
+                    width: 120px;
+                    height: 30px;
+                    label: apply_armed ? "Disarm Apply" : "Arm Apply";
+                    clicked => { root.toggle-apply-arm(); }
+                }
+
+                ActionButton {
+                    width: 120px;
+                    height: 30px;
+                    label: "Apply to Files";
+                    clicked => { root.apply-staged-edits(); }
+                }
+            }
+
+            Text {
+                text: export_status;
+                color: #a5bed9;
+                x: 14px;
+                y: 76px;
+                width: parent.width - 28px;
+                wrap: word-wrap;
+            }
+
+            Text {
+                text: "Writes are blocked until apply is armed. Review the preview before applying.";
+                color: #c8a68a;
+                x: 14px;
+                y: 98px;
+                width: parent.width - 28px;
+                wrap: word-wrap;
+            }
+
+            Rectangle {
+                x: 12px;
+                y: 126px;
+                width: parent.width - 24px;
+                height: parent.height - 138px;
+                border-color: #27374a;
+                border-width: 1px;
+                border-radius: 8px;
+                background: #0f1721;
+                clip: true;
+
+                Text {
+                    text: patch_preview;
+                    color: #d7e5f8;
+                    x: 10px;
+                    y: 8px;
+                    width: parent.width - 20px;
+                    wrap: word-wrap;
+                }
+            }
+        }
+
+        Rectangle {
+            border-color: #2c3a49;
+            border-width: 1px;
+            border-radius: 8px;
+            background: #111a24;
+            height: 34px;
+
+            Text {
+                text: status_text;
+                color: #d2deee;
+                x: 12px;
+                y: 8px;
+            }
+        }
+    }
+}

--- a/.harmony/runtime/run
+++ b/.harmony/runtime/run
@@ -33,6 +33,12 @@ case "$OS" in
     ;;
 esac
 
+case "${1:-}" in
+  ""|studio|-h|--help|help)
+    BIN=""
+    ;;
+esac
+
 if [ -n "${BIN:-}" ] && [ -x "$BIN" ]; then
   exec "$BIN" "$@"
 fi

--- a/.harmony/runtime/run.cmd
+++ b/.harmony/runtime/run.cmd
@@ -16,6 +16,12 @@ if defined PROCESSOR_ARCHITEW6432 set ARCH=%PROCESSOR_ARCHITEW6432%
 
 set BIN=%RUNTIME_OPS_DIR%\bin\harmony-windows-x64.exe
 
+if /I "%~1"=="studio" set BIN=
+if "%~1"=="" set BIN=
+if /I "%~1"=="-h" set BIN=
+if /I "%~1"=="--help" set BIN=
+if /I "%~1"=="help" set BIN=
+
 if exist "%BIN%" (
   "%BIN%" %*
   exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary
- add a new harmony_studio Slint desktop crate for workflow graph design and inspection
- add staged edit buffer, patch preview export, guarded apply, rollback safety, and apply audit indexing/filtering
- wire runtime launch via `harmony studio` and `.harmony/runtime/run studio` and add `/studio` command discoverability
- add tests for studio app state flows and kernel CLI studio command/help coverage
- document launch and verification guidance in START, catalog, runtime README, and runtime verification scenarios

## Validation
- cargo check -p harmony_studio -p harmony_kernel
- cargo test -p harmony_studio -p harmony_kernel
- .harmony/runtime/run --help
- .harmony/runtime/run studio --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus command catalog/manifest indexing; no runtime behavior or data/security logic is modified in this diff.
> 
> **Overview**
> **Adds a new `studio` command entry** to the commands manifest and catalog, including a new `capabilities/commands/studio.md` doc describing usage/parameters and how it maps to `.harmony/runtime/run studio`.
> 
> Updates onboarding and runtime docs (`START.md`, `runtime/README.md`) plus manual verification scenarios to include Studio launch quick-start and expected `--help` output discoverability checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c33c553f8718d0cbaffffc0d57ed0e34bfb3924d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->