### PR TITLE
chore(ci): add phase a autonomy workflows

### DIFF
--- a/.github/workflows/pr-autonomy-policy.yml
+++ b/.github/workflows/pr-autonomy-policy.yml
@@ -1,0 +1,187 @@
+name: PR Autonomy Policy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      # Phase A default: advisory mode. Set to "true" in Phase B.
+      AUTONOMY_POLICY_ENFORCE: ${{ vars.AUTONOMY_POLICY_ENFORCE }}
+    steps:
+      - name: Validate autonomy policy (advisory by default)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const pull_number = pr.number;
+            const baseSha = pr.base?.sha;
+
+            const body = (pr.body || "").trim();
+            const title = (pr.title || "").trim();
+            const headRef = pr.head?.ref || "";
+            const author = pr.user?.login || "";
+            const labels = new Set((pr.labels || []).map((l) => l.name));
+
+            const isDependabot = author === "dependabot[bot]" || headRef.startsWith("dependabot/");
+            const isAutorelease = headRef.startsWith("release-please--") || [...labels].some((name) => name.startsWith("autorelease:"));
+            const isBotPath = isDependabot || isAutorelease;
+            const enforce = String(process.env.AUTONOMY_POLICY_ENFORCE || "").toLowerCase() === "true";
+
+            const errors = [];
+
+            if (!baseSha) {
+              errors.push("Unable to determine PR base SHA.");
+            }
+
+            async function readTextFile(path) {
+              const response = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path,
+                ref: baseSha
+              });
+
+              if (Array.isArray(response.data) || !("content" in response.data)) {
+                throw new Error(`Expected file content at ${path}, received non-file response.`);
+              }
+
+              return Buffer.from(
+                response.data.content,
+                response.data.encoding || "base64"
+              ).toString("utf8");
+            }
+
+            let standards;
+            let templateText;
+            try {
+              standards = JSON.parse(await readTextFile(".harmony/agency/practices/standards/commit-pr-standards.json"));
+              templateText = await readTextFile(".github/PULL_REQUEST_TEMPLATE.md");
+            } catch (error) {
+              errors.push(`Could not load standards/template from base SHA: ${error.message}`);
+            }
+
+            if (!isBotPath && standards) {
+              const allowedTypes = (standards.commit?.allowed_types || []).map((value) =>
+                String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+              ).join("|");
+              const scopePattern = standards.commit?.scope_pattern || "[a-z0-9][a-z0-9-]*";
+              const titleRegex = new RegExp(`^(?<type>${allowedTypes})\\((?<scope>${scopePattern})\\)(?<breaking>!)?: (?<summary>.+)$`);
+
+              const titleMatch = title.match(titleRegex);
+              if (!titleMatch || !titleMatch.groups) {
+                errors.push(`PR title '${title}' must match Conventional Commits format ${standards.commit?.header_format || "<type>(<scope>): <summary>"}.`);
+              } else {
+                const summary = titleMatch.groups.summary || "";
+                if (standards.commit?.summary_must_be_lowercase && summary !== summary.toLowerCase()) {
+                  errors.push("PR title summary must be lowercase.");
+                }
+                if (standards.commit?.summary_must_not_end_with_period && summary.endsWith(".")) {
+                  errors.push("PR title summary must not end with a period.");
+                }
+                if (standards.commit?.header_max_length && title.length > standards.commit.header_max_length) {
+                  errors.push(`PR title exceeds ${standards.commit.header_max_length} characters.`);
+                }
+              }
+            }
+
+            if (!isBotPath && standards) {
+              const branch = standards.branch || {};
+              const allowedTypes = (branch.allowed_types || []).map((value) =>
+                String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+              ).join("|");
+              const ticketPattern = branch.ticket_pattern || "[A-Za-z0-9]+-[0-9]+";
+              const slugPattern = branch.slug_pattern || "[a-z0-9]+(?:-[a-z0-9]+)*";
+              const branchRegex = new RegExp(`^(?<type>${allowedTypes})/(?:(?<ticket>${ticketPattern})-)?(?<slug>${slugPattern})$`);
+
+              if (!branchRegex.test(headRef)) {
+                errors.push(
+                  `Branch '${headRef}' must match ${branch.default_format || "<type>/<ticket-id>-<short-description>"} with allowed types: ${(branch.allowed_types || []).join(", ")}.`
+                );
+              }
+            }
+
+            if (headRef.startsWith("exp/")) {
+              errors.push("Branches under 'exp/' are non-mergeable in autonomy policy. Rename branch before merge.");
+            }
+
+            if (!isBotPath && templateText) {
+              const headingMatches = [...templateText.matchAll(/^##\s+(.+)\s*$/gm)];
+              const headings = headingMatches.map((match) => `## ${match[1].trim()}`);
+              const checklistHeading = "## Checklist";
+              const checklistIndex = headings.indexOf(checklistHeading);
+
+              if (checklistIndex === -1) {
+                errors.push("Canonical template is missing '## Checklist'.");
+              } else {
+                const requiredHeadings = headings.slice(0, checklistIndex + 1);
+                const missingHeadings = requiredHeadings.filter((heading) => {
+                  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                  return !new RegExp(`^${escaped}\\s*$`, "mi").test(body);
+                });
+                if (missingHeadings.length > 0) {
+                  errors.push(`PR body missing required sections: ${missingHeadings.join(", ")}`);
+                }
+              }
+
+              const hasIssueLink = /(close[sd]?|fixe?[sd]?|resolve[sd]?)\s+#\d+/i.test(body);
+              const hasNoIssue = /No-Issue:\s*\S+/i.test(body);
+              if (!hasIssueLink && !hasNoIssue) {
+                errors.push("PR body must include issue linkage (`Closes/Fixes/Resolves #...`) or `No-Issue: <reason>`.");
+              }
+            }
+
+            const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100
+            });
+            const paths = changedFiles.map((file) => file.filename);
+
+            const highImpactPaths = [
+              ".github/",
+              "AGENTS.md",
+              ".harmony/agency/governance/",
+              ".harmony/cognition/governance/",
+              ".harmony/capabilities/governance/",
+              ".harmony/engine/governance/",
+              ".harmony/engine/runtime/spec/",
+              ".harmony/assurance/governance/"
+            ];
+
+            const isHighImpact = paths.some((path) => highImpactPaths.some((prefix) => path.startsWith(prefix) || path === prefix));
+            if (isHighImpact && !labels.has("accept:human")) {
+              errors.push("High-impact change requires explicit `accept:human` label before merge.");
+            }
+
+            if (errors.length === 0) {
+              core.info(`Autonomy policy passed (${enforce ? "enforced" : "advisory"} mode).`);
+              return;
+            }
+
+            const details = errors.map((item) => `- ${item}`).join("\n");
+            if (enforce) {
+              core.setFailed(`Autonomy policy failed (enforced mode):\n${details}`);
+              return;
+            }
+
+            core.warning(`Autonomy policy found ${errors.length} issue(s) in advisory mode:\n${details}`);
+            core.notice("Phase A advisory mode active. Set repo variable AUTONOMY_POLICY_ENFORCE=true to enforce failures.");

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,247 @@
+name: PR Triage
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  triage:
+    name: triage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Auto-label and normalize bot titles
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const pull_number = pr.number;
+
+            const headRef = pr.head?.ref || "";
+            const author = pr.user?.login || "";
+            const labels = new Set((pr.labels || []).map((l) => l.name));
+            const currentTitle = pr.title || "";
+
+            const isDependabot = author === "dependabot[bot]" || headRef.startsWith("dependabot/");
+
+            // Keep this label catalog minimal and aligned to this phase.
+            const labelCatalog = {
+              "type:feat": { color: "1D76DB", description: "New feature" },
+              "type:fix": { color: "D73A4A", description: "Bug fix" },
+              "type:refactor": { color: "A2EEEF", description: "Refactor" },
+              "type:perf": { color: "C2E0C6", description: "Performance improvement" },
+              "type:test": { color: "FBCA04", description: "Tests" },
+              "type:docs": { color: "0075CA", description: "Documentation" },
+              "type:chore": { color: "C5DEF5", description: "Maintenance and chores" },
+              "type:ci": { color: "5319E7", description: "CI or automation" },
+              "type:revert": { color: "BFD4F2", description: "Revert change" },
+              "type:unknown": { color: "D4C5F9", description: "Unclassified branch type" },
+
+              "area:agency": { color: "0E8A16", description: "Harmony agency domain" },
+              "area:capabilities": { color: "0E8A16", description: "Harmony capabilities domain" },
+              "area:cognition": { color: "0E8A16", description: "Harmony cognition domain" },
+              "area:orchestration": { color: "0E8A16", description: "Harmony orchestration domain" },
+              "area:scaffolding": { color: "0E8A16", description: "Harmony scaffolding domain" },
+              "area:assurance": { color: "0E8A16", description: "Harmony assurance domain" },
+              "area:engine": { color: "0E8A16", description: "Harmony engine domain" },
+              "area:continuity": { color: "0E8A16", description: "Harmony continuity domain" },
+              "area:ideation": { color: "0E8A16", description: "Harmony ideation domain" },
+              "area:output": { color: "0E8A16", description: "Harmony output domain" },
+              "area:github": { color: "0052CC", description: "GitHub workflow or settings surface" },
+              "area:root": { color: "0052CC", description: "Root contract or repository surface" },
+              "area:uncategorized": { color: "BFDADC", description: "No known area match" },
+
+              "risk:low": { color: "D4C5F9", description: "Low risk routine change" },
+              "risk:med": { color: "FBCA04", description: "Medium risk change" },
+              "risk:high": { color: "B60205", description: "High impact governance/control-plane change" },
+
+              "accept:human": { color: "000000", description: "Explicit human acceptance for high-impact merge" },
+              "autonomy:auto-merge": { color: "1B8835", description: "Eligible for autonomous auto-merge lane" },
+              "autonomy:no-automerge": { color: "B60205", description: "Excluded from autonomous auto-merge lane" },
+              "bot:dependabot": { color: "0366D6", description: "Dependabot pull request" }
+            };
+
+            async function ensureLabel(name) {
+              const cfg = labelCatalog[name];
+              if (!cfg) return;
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status === 404) {
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner,
+                      repo,
+                      name,
+                      color: cfg.color,
+                      description: cfg.description
+                    });
+                    core.info(`Created label: ${name}`);
+                  } catch (createError) {
+                    core.warning(`Could not create label ${name}: ${createError.message}`);
+                  }
+                } else {
+                  core.warning(`Could not read label ${name}: ${error.message}`);
+                }
+              }
+            }
+
+            // Read changed files directly from API (no checkout in pull_request_target).
+            const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100
+            });
+            const paths = changedFiles.map((f) => f.filename);
+
+            const typeFromPrefix = {
+              feat: "type:feat",
+              fix: "type:fix",
+              refactor: "type:refactor",
+              perf: "type:perf",
+              test: "type:test",
+              docs: "type:docs",
+              chore: "type:chore",
+              ci: "type:ci",
+              revert: "type:revert"
+            };
+
+            const branchPrefix = headRef.split("/")[0] || "";
+            let desiredType = typeFromPrefix[branchPrefix] || "type:unknown";
+            if (isDependabot) {
+              desiredType = "type:chore";
+            }
+
+            const areaPrefixMap = [
+              [".harmony/agency/", "area:agency"],
+              [".harmony/capabilities/", "area:capabilities"],
+              [".harmony/cognition/", "area:cognition"],
+              [".harmony/orchestration/", "area:orchestration"],
+              [".harmony/scaffolding/", "area:scaffolding"],
+              [".harmony/assurance/", "area:assurance"],
+              [".harmony/engine/", "area:engine"],
+              [".harmony/continuity/", "area:continuity"],
+              [".harmony/ideation/", "area:ideation"],
+              [".harmony/output/", "area:output"],
+              [".github/", "area:github"]
+            ];
+
+            const desiredAreas = new Set();
+            for (const path of paths) {
+              let matched = false;
+              for (const [prefix, label] of areaPrefixMap) {
+                if (path.startsWith(prefix)) {
+                  desiredAreas.add(label);
+                  matched = true;
+                }
+              }
+
+              if (!matched && !path.includes("/")) {
+                desiredAreas.add("area:root");
+                matched = true;
+              }
+            }
+            if (desiredAreas.size === 0) {
+              desiredAreas.add("area:uncategorized");
+            }
+
+            const highImpactPathPatterns = [
+              ".github/",
+              "AGENTS.md",
+              ".harmony/agency/governance/",
+              ".harmony/cognition/governance/",
+              ".harmony/capabilities/governance/",
+              ".harmony/engine/governance/",
+              ".harmony/engine/runtime/spec/",
+              ".harmony/assurance/governance/"
+            ];
+            const mediumImpactPathPatterns = [
+              ".harmony/agency/runtime/",
+              ".harmony/capabilities/runtime/",
+              ".harmony/orchestration/runtime/",
+              ".harmony/assurance/runtime/",
+              ".harmony/engine/runtime/"
+            ];
+
+            const isHighImpact = paths.some((path) => highImpactPathPatterns.some((prefix) => path.startsWith(prefix) || path === prefix));
+            const isMediumImpact = !isHighImpact && paths.some((path) => mediumImpactPathPatterns.some((prefix) => path.startsWith(prefix)));
+
+            const desiredRisk = isHighImpact ? "risk:high" : (isMediumImpact ? "risk:med" : "risk:low");
+
+            const desiredLabels = new Set([desiredType, desiredRisk, ...desiredAreas]);
+            if (isDependabot) {
+              desiredLabels.add("bot:dependabot");
+            }
+
+            // Keep exactly one type and one risk label managed by triage.
+            const labelsToRemove = [];
+            for (const current of labels) {
+              if (current.startsWith("type:") && current !== desiredType) {
+                labelsToRemove.push(current);
+              }
+              if (current.startsWith("risk:") && current !== desiredRisk) {
+                labelsToRemove.push(current);
+              }
+            }
+
+            // Best effort label creation and mutation.
+            for (const name of desiredLabels) {
+              await ensureLabel(name);
+            }
+
+            const labelsToAdd = [...desiredLabels].filter((name) => !labels.has(name));
+            if (labelsToAdd.length > 0) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  labels: labelsToAdd
+                });
+                core.info(`Added labels: ${labelsToAdd.join(", ")}`);
+              } catch (error) {
+                core.warning(`Could not add one or more labels: ${error.message}`);
+              }
+            }
+
+            for (const name of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  name
+                });
+                core.info(`Removed label: ${name}`);
+              } catch (error) {
+                core.warning(`Could not remove label ${name}: ${error.message}`);
+              }
+            }
+
+            const conventionalRegex = /^(feat|fix|refactor|perf|test|docs|chore|ci|revert)(\([a-z0-9][a-z0-9-]*\))?!?: .+/;
+            if (isDependabot && !conventionalRegex.test(currentTitle)) {
+              const normalized = `chore(deps): ${currentTitle}`.replace(/\s+/g, " ").trim().slice(0, 256);
+              try {
+                await github.rest.pulls.update({ owner, repo, pull_number, title: normalized });
+                core.info(`Normalized dependabot title: ${normalized}`);
+              } catch (error) {
+                core.warning(`Could not normalize dependabot title: ${error.message}`);
+              }
+            }
+
+            if (isHighImpact) {
+              core.notice("High-impact change detected. Explicit 'accept:human' is required by autonomy policy before merge.");
+            }


### PR DESCRIPTION
## What
Adds the two Phase A shadow-validation workflows: PR Triage and PR Autonomy Policy.

## Why
No-Issue: phase-a-shadow-bootstrap

## How
Introduces new workflow files under `.github/workflows/` without changing existing required checks.

## Tradeoffs
Adds temporary workflow surface area while we validate behavior in advisory mode.

## Testing
- Ran local YAML parse for both new workflows.
- Shadow validation PRs opened against the shadow base branch.

## Rollout
Advisory mode only (`AUTONOMY_POLICY_ENFORCE=false`).

## Risk Rubric
- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High
- Rollback plan: revert this PR
- Flags changed (name, owner, expiry, rollout): AUTONOMY_POLICY_ENFORCE=false

## Contracts and Threat Model
- OpenAPI/JSON-Schema changes: none
- Threat model update/link: n/a

## Observability and Performance
- Traces/logs/metrics for changed flows: GitHub Actions workflow logs
- Representative traces for high risk changes: n/a
- Performance or bundle impact: none

## License and Provenance
- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist
- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes
n/a
