### PR TITLE
docs(agency): add phase c pat troubleshooting notes

### DIFF
--- a/.harmony/agency/practices/github-autonomy-runbook.md
+++ b/.harmony/agency/practices/github-autonomy-runbook.md
@@ -115,3 +115,11 @@ For Phase C release acceleration:
 When broadening PAT permissions, document the reason and workflow dependency in
 the same PR. Prefer the smallest permission set that keeps autonomous merging
 functional.
+
+## Troubleshooting
+
+- `release-please` fails with
+  `Resource not accessible by personal access token ... create-a-pull-request`:
+  `AUTONOMY_PAT` is missing `Pull requests: Read and write`.
+- `release-please` fails when applying labels/comments on release PR:
+  `AUTONOMY_PAT` is missing `Issues: Read and write`.


### PR DESCRIPTION
## What
Adds troubleshooting notes to the autonomy runbook for common Phase C PAT scope failures.

## Why
No-Issue: document the exact release-please PAT permission failure modes observed during Phase C validation.

## How
- Added troubleshooting bullets for missing `Pull requests: Read and write` and `Issues: Read and write` in `AUTONOMY_PAT`.

## Tradeoffs
- none

## Testing
- Documentation-only update.

## Rollout
- Immediate once merged.

## Risk Rubric
- Risk class: [x] Trivial [ ] Low [ ] Medium [ ] High
- Rollback plan: Revert this commit.
- Flags changed (name, owner, expiry, rollout): none

## Contracts and Threat Model
- OpenAPI/JSON-Schema changes: none
- Threat model update/link: n/a

## Observability and Performance
- Traces/logs/metrics for changed flows: n/a
- Representative traces for high risk changes: n/a
- Performance or bundle impact: none

## License and Provenance
- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist
- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes
n/a
