### PR TITLE
feat(agency): add local git autonomy helper scripts

### DIFF
--- a/.harmony/agency/_ops/scripts/git-pr-open.sh
+++ b/.harmony/agency/_ops/scripts/git-pr-open.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TITLE=""
+SUMMARY="Autonomy helper: open draft PR."
+HOW_TEXT="Uses the local autonomy script to create a draft PR scaffold."
+TRADEOFFS_TEXT="n/a"
+TESTING_TEXT="Pending; update before marking ready."
+ROLLOUT_TEXT="n/a"
+ISSUE_NUMBER=""
+NO_ISSUE_REASON="autonomy-script"
+COMMIT_MESSAGE=""
+BASE_BRANCH="main"
+DRAFT=1
+DRY_RUN=0
+LABELS_CSV=""
+STAGE_ALL=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  git-pr-open.sh --title "<type(scope): summary>" [options]
+
+Options:
+  --summary <text>           Replace default "What" section summary.
+  --issue <number>           Add "Closes #<number>" linkage to PR body.
+  --no-issue <reason>        Add "No-Issue: <reason>" linkage (default).
+  --commit-message <text>    Commit message for staged changes (defaults to --title).
+  --base <branch>            Base branch for PR creation (default: main).
+  --ready                    Open non-draft PR instead of draft.
+  --label <name>             Add label at PR creation (repeatable).
+  --stage-all                Stage all tracked/untracked files before commit.
+  --dry-run                  Print actions without mutating state.
+
+Behavior:
+  - Commits staged changes, or stages all changes with --stage-all.
+  - Pushes current branch to origin.
+  - Creates a PR body from .github/PULL_REQUEST_TEMPLATE.md with issue linkage.
+USAGE
+}
+
+error() {
+  echo "[ERROR] $1" >&2
+  exit 1
+}
+
+info() {
+  echo "[INFO] $1"
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || error "Missing required command: $cmd"
+}
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || true
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)
+      shift
+      [[ $# -gt 0 ]] || error "--title requires a value"
+      TITLE="$1"
+      ;;
+    --summary)
+      shift
+      [[ $# -gt 0 ]] || error "--summary requires a value"
+      SUMMARY="$1"
+      ;;
+    --issue)
+      shift
+      [[ $# -gt 0 ]] || error "--issue requires a value"
+      ISSUE_NUMBER="$1"
+      ;;
+    --no-issue)
+      shift
+      [[ $# -gt 0 ]] || error "--no-issue requires a value"
+      NO_ISSUE_REASON="$1"
+      ;;
+    --commit-message)
+      shift
+      [[ $# -gt 0 ]] || error "--commit-message requires a value"
+      COMMIT_MESSAGE="$1"
+      ;;
+    --base)
+      shift
+      [[ $# -gt 0 ]] || error "--base requires a value"
+      BASE_BRANCH="$1"
+      ;;
+    --ready)
+      DRAFT=0
+      ;;
+    --label)
+      shift
+      [[ $# -gt 0 ]] || error "--label requires a value"
+      if [[ -z "$LABELS_CSV" ]]; then
+        LABELS_CSV="$1"
+      else
+        LABELS_CSV="${LABELS_CSV},$1"
+      fi
+      ;;
+    --stage-all)
+      STAGE_ALL=1
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      error "Unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+require_cmd git
+require_cmd gh
+require_cmd jq
+
+REPO_ROOT="$(repo_root)"
+[[ -n "$REPO_ROOT" ]] || error "Run this command from inside a git repository."
+
+STANDARDS_FILE="$REPO_ROOT/.harmony/agency/practices/standards/commit-pr-standards.json"
+TEMPLATE_FILE="$REPO_ROOT/.github/PULL_REQUEST_TEMPLATE.md"
+
+[[ -f "$STANDARDS_FILE" ]] || error "Missing standards file: $STANDARDS_FILE"
+[[ -f "$TEMPLATE_FILE" ]] || error "Missing PR template file: $TEMPLATE_FILE"
+[[ -n "$TITLE" ]] || error "--title is required."
+
+if [[ -n "$ISSUE_NUMBER" && "$NO_ISSUE_REASON" != "autonomy-script" ]]; then
+  error "Use either --issue or --no-issue, not both."
+fi
+
+if [[ -z "$COMMIT_MESSAGE" ]]; then
+  COMMIT_MESSAGE="$TITLE"
+fi
+
+ALLOWED_TYPES_REGEX="$(jq -r '.commit.allowed_types | join("|")' "$STANDARDS_FILE")"
+SCOPE_PATTERN="$(jq -r '.commit.scope_pattern' "$STANDARDS_FILE")"
+COMMIT_HEADER_MAX="$(jq -r '.commit.header_max_length' "$STANDARDS_FILE")"
+SUMMARY_LOWERCASE="$(jq -r '.commit.summary_must_be_lowercase' "$STANDARDS_FILE")"
+SUMMARY_NO_PERIOD="$(jq -r '.commit.summary_must_not_end_with_period' "$STANDARDS_FILE")"
+
+TITLE_REGEX="^(${ALLOWED_TYPES_REGEX})\\(${SCOPE_PATTERN}\\)!?: .+"
+COMMIT_REGEX="^(${ALLOWED_TYPES_REGEX})\\(${SCOPE_PATTERN}\\): (.+)$"
+
+[[ "$TITLE" =~ $TITLE_REGEX ]] || error "PR title must match conventional format: <type>(<scope>): <summary>"
+
+if [[ ${#COMMIT_MESSAGE} -gt "$COMMIT_HEADER_MAX" ]]; then
+  error "Commit message header exceeds ${COMMIT_HEADER_MAX} characters."
+fi
+
+if [[ ! "$COMMIT_MESSAGE" =~ $COMMIT_REGEX ]]; then
+  error "Commit message must match contract: <type>(<scope>): <summary>"
+fi
+
+COMMIT_SUMMARY="${BASH_REMATCH[2]}"
+if [[ "$SUMMARY_LOWERCASE" == "true" ]]; then
+  COMMIT_SUMMARY_LOWER="$(printf '%s' "$COMMIT_SUMMARY" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$COMMIT_SUMMARY" != "$COMMIT_SUMMARY_LOWER" ]]; then
+    error "Commit summary must be lowercase."
+  fi
+fi
+if [[ "$SUMMARY_NO_PERIOD" == "true" && "$COMMIT_SUMMARY" == *"." ]]; then
+  error "Commit summary must not end with a period."
+fi
+
+CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+[[ "$CURRENT_BRANCH" != "HEAD" ]] || error "Detached HEAD is not supported."
+[[ "$CURRENT_BRANCH" != "main" ]] || error "Refusing to open PR from main. Create a feature branch first."
+
+HAS_STAGED=1
+git -C "$REPO_ROOT" diff --cached --quiet && HAS_STAGED=0 || true
+HAS_DIRTY=0
+[[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]] && HAS_DIRTY=1 || true
+
+if [[ "$HAS_STAGED" -eq 0 && "$HAS_DIRTY" -eq 1 && "$STAGE_ALL" -eq 1 ]]; then
+  info "Staging all working tree changes."
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] git -C \"$REPO_ROOT\" add -A"
+  else
+    git -C "$REPO_ROOT" add -A
+  fi
+  HAS_STAGED=1
+fi
+
+if [[ "$HAS_STAGED" -eq 1 ]]; then
+  info "Committing staged changes."
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] git -C \"$REPO_ROOT\" commit -m \"$COMMIT_MESSAGE\""
+  else
+    git -C "$REPO_ROOT" commit -m "$COMMIT_MESSAGE"
+  fi
+elif [[ "$HAS_DIRTY" -eq 1 ]]; then
+  error "Working tree has unstaged changes. Stage intended files or use --stage-all."
+else
+  info "No local changes to commit."
+fi
+
+if git -C "$REPO_ROOT" rev-parse --abbrev-ref --symbolic-full-name "@{u}" >/dev/null 2>&1; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] git -C \"$REPO_ROOT\" push"
+  else
+    git -C "$REPO_ROOT" push
+  fi
+else
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] git -C \"$REPO_ROOT\" push -u origin \"$CURRENT_BRANCH\""
+  else
+    git -C "$REPO_ROOT" push -u origin "$CURRENT_BRANCH"
+  fi
+fi
+
+if [[ -n "$ISSUE_NUMBER" ]]; then
+  ISSUE_LINK="Closes #${ISSUE_NUMBER}"
+else
+  ISSUE_LINK="No-Issue: ${NO_ISSUE_REASON}"
+fi
+
+WHY_TEXT="${SUMMARY} ${ISSUE_LINK}"
+
+BODY_TMP="$(mktemp "${TMPDIR:-/tmp}/harmony-pr-body.XXXXXX")"
+awk \
+  -v what="$SUMMARY" \
+  -v why="$WHY_TEXT" \
+  -v how="$HOW_TEXT" \
+  -v tradeoffs="$TRADEOFFS_TEXT" \
+  -v testing="$TESTING_TEXT" \
+  -v rollout="$ROLLOUT_TEXT" '
+  $0 == "One or two sentences describing what this PR changes." {
+    print what
+    next
+  }
+  $0 == "The problem this solves and why it matters. Include ticket/issue links." {
+    print why
+    next
+  }
+  $0 == "Approach summary, including non-obvious design choices and alternatives rejected." {
+    print how
+    next
+  }
+  $0 == "Known compromises, remaining risks, and any follow-up tickets." {
+    print tradeoffs
+    next
+  }
+  $0 == "How this was verified (automated and manual), including edge cases covered." {
+    print testing
+    next
+  }
+  $0 == "Release strategy (flags, migration sequencing, canary/gradual rollout) or `n/a`." {
+    print rollout
+    next
+  }
+  $0 == "- Risk class: [ ] Trivial [ ] Low [ ] Medium [ ] High" {
+    print "- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High"
+    next
+  }
+  $0 == "- Rollback plan:" {
+    print "- Rollback plan: revert the squash commit if needed."
+    next
+  }
+  $0 == "- Flags changed (name, owner, expiry, rollout):" {
+    print "- Flags changed (name, owner, expiry, rollout): none."
+    next
+  }
+  { print }
+' "$TEMPLATE_FILE" > "$BODY_TMP"
+
+PR_ARGS=(pr create --base "$BASE_BRANCH" --head "$CURRENT_BRANCH" --title "$TITLE" --body-file "$BODY_TMP")
+if [[ "$DRAFT" -eq 1 ]]; then
+  PR_ARGS+=(--draft)
+fi
+if [[ -n "$LABELS_CSV" ]]; then
+  PR_ARGS+=(--label "$LABELS_CSV")
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[DRY] gh ${PR_ARGS[*]}"
+  rm -f "$BODY_TMP"
+  exit 0
+fi
+
+gh "${PR_ARGS[@]}"
+rm -f "$BODY_TMP"

--- a/.harmony/agency/_ops/scripts/git-pr-ship.sh
+++ b/.harmony/agency/_ops/scripts/git-pr-ship.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PR_NUMBER=""
+ADD_ACCEPT_HUMAN=0
+MARK_READY=1
+REQUEST_AUTOMERGE=1
+ADD_AUTO_LABEL=1
+DRY_RUN=0
+LABELS_CSV=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  git-pr-ship.sh [--pr <number>] [options]
+
+Options:
+  --label <name>         Add additional label(s) before shipping (repeatable).
+  --accept-human         Add accept:human label.
+  --no-ready             Do not convert draft PR to ready state.
+  --no-auto-label        Do not add autonomy:auto-merge.
+  --no-automerge         Skip auto-merge request call.
+  --dry-run              Print actions without mutating PR state.
+
+Default behavior:
+  1) Add autonomy:auto-merge (and remove autonomy:no-automerge),
+  2) mark draft PR as ready,
+  3) request squash auto-merge.
+USAGE
+}
+
+error() {
+  echo "[ERROR] $1" >&2
+  exit 1
+}
+
+info() {
+  echo "[INFO] $1"
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || error "Missing required command: $cmd"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      shift
+      [[ $# -gt 0 ]] || error "--pr requires a value"
+      PR_NUMBER="$1"
+      ;;
+    --label)
+      shift
+      [[ $# -gt 0 ]] || error "--label requires a value"
+      if [[ -z "$LABELS_CSV" ]]; then
+        LABELS_CSV="$1"
+      else
+        LABELS_CSV="${LABELS_CSV},$1"
+      fi
+      ;;
+    --accept-human)
+      ADD_ACCEPT_HUMAN=1
+      ;;
+    --no-ready)
+      MARK_READY=0
+      ;;
+    --no-auto-label)
+      ADD_AUTO_LABEL=0
+      ;;
+    --no-automerge)
+      REQUEST_AUTOMERGE=0
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      error "Unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+require_cmd gh
+require_cmd jq
+
+if [[ -z "$PR_NUMBER" ]]; then
+  PR_NUMBER="$(gh pr view --json number --jq '.number' 2>/dev/null || true)"
+  [[ -n "$PR_NUMBER" ]] || error "Unable to resolve current branch PR. Pass --pr <number>."
+fi
+
+PR_PAYLOAD="$(gh pr view "$PR_NUMBER" --json state,isDraft,url,headRefName 2>/dev/null || true)"
+[[ -n "$PR_PAYLOAD" ]] || error "Unable to load PR #${PR_NUMBER}."
+
+PR_STATE="$(jq -r '.state' <<<"$PR_PAYLOAD")"
+PR_IS_DRAFT="$(jq -r '.isDraft' <<<"$PR_PAYLOAD")"
+PR_URL="$(jq -r '.url' <<<"$PR_PAYLOAD")"
+
+if [[ "$PR_STATE" != "OPEN" ]]; then
+  error "PR #${PR_NUMBER} is not open (state=$PR_STATE)."
+fi
+
+LABELS_TO_ADD=""
+if [[ "$ADD_AUTO_LABEL" -eq 1 ]]; then
+  LABELS_TO_ADD="autonomy:auto-merge"
+fi
+if [[ "$ADD_ACCEPT_HUMAN" -eq 1 ]]; then
+  if [[ -z "$LABELS_TO_ADD" ]]; then
+    LABELS_TO_ADD="accept:human"
+  else
+    LABELS_TO_ADD="${LABELS_TO_ADD},accept:human"
+  fi
+fi
+if [[ -n "$LABELS_CSV" ]]; then
+  if [[ -z "$LABELS_TO_ADD" ]]; then
+    LABELS_TO_ADD="$LABELS_CSV"
+  else
+    LABELS_TO_ADD="${LABELS_TO_ADD},${LABELS_CSV}"
+  fi
+fi
+
+if [[ -n "$LABELS_TO_ADD" ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] gh pr edit \"$PR_NUMBER\" --add-label \"$LABELS_TO_ADD\""
+  else
+    gh pr edit "$PR_NUMBER" --add-label "$LABELS_TO_ADD"
+  fi
+fi
+
+if [[ "$ADD_AUTO_LABEL" -eq 1 ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] gh pr edit \"$PR_NUMBER\" --remove-label \"autonomy:no-automerge\""
+  else
+    gh pr edit "$PR_NUMBER" --remove-label "autonomy:no-automerge" >/dev/null 2>&1 || true
+  fi
+fi
+
+if [[ "$MARK_READY" -eq 1 && "$PR_IS_DRAFT" == "true" ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] gh pr ready \"$PR_NUMBER\""
+  else
+    gh pr ready "$PR_NUMBER"
+  fi
+fi
+
+if [[ "$REQUEST_AUTOMERGE" -eq 1 ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] gh pr merge \"$PR_NUMBER\" --auto --squash --delete-branch"
+  else
+    gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
+  fi
+fi
+
+echo "[OK] PR ready for autonomy lane: $PR_URL"
+

--- a/.harmony/agency/_ops/scripts/git-wt-new.sh
+++ b/.harmony/agency/_ops/scripts/git-wt-new.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="main"
+TYPE=""
+SLUG=""
+TICKET=""
+BRANCH=""
+WORKTREE_PATH=""
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  git-wt-new.sh --type <type> --slug <slug> [--ticket <ABC-123>] [--base <branch>] [--worktree <path>] [--dry-run]
+  git-wt-new.sh --branch <type/slug-or-ticket-slug> [--base <branch>] [--worktree <path>] [--dry-run]
+
+Creates a new git worktree and branch using repository branch naming standards.
+USAGE
+}
+
+error() {
+  echo "[ERROR] $1" >&2
+  exit 1
+}
+
+info() {
+  echo "[INFO] $1"
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || error "Missing required command: $cmd"
+}
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || true
+}
+
+contains_type() {
+  local target="$1"
+  local value
+  for value in ${ALLOWED_TYPES}; do
+    if [[ "$value" == "$target" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+validate_branch() {
+  local branch_name="$1"
+  local pattern="^(${ALLOWED_TYPES_REGEX})/((${BASH_TICKET_PATTERN})-)?(${BASH_SLUG_PATTERN})$"
+
+  if [[ ! "$branch_name" =~ $pattern ]]; then
+    error "Branch '$branch_name' does not match branch policy contract."
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type)
+      shift
+      [[ $# -gt 0 ]] || error "--type requires a value"
+      TYPE="$1"
+      ;;
+    --slug)
+      shift
+      [[ $# -gt 0 ]] || error "--slug requires a value"
+      SLUG="$1"
+      ;;
+    --ticket)
+      shift
+      [[ $# -gt 0 ]] || error "--ticket requires a value"
+      TICKET="$1"
+      ;;
+    --branch)
+      shift
+      [[ $# -gt 0 ]] || error "--branch requires a value"
+      BRANCH="$1"
+      ;;
+    --base)
+      shift
+      [[ $# -gt 0 ]] || error "--base requires a value"
+      BASE_BRANCH="$1"
+      ;;
+    --worktree)
+      shift
+      [[ $# -gt 0 ]] || error "--worktree requires a value"
+      WORKTREE_PATH="$1"
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      error "Unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+require_cmd git
+require_cmd jq
+
+REPO_ROOT="$(repo_root)"
+[[ -n "$REPO_ROOT" ]] || error "Run this command from within a git repository."
+
+STANDARDS_FILE="$REPO_ROOT/.harmony/agency/practices/standards/commit-pr-standards.json"
+[[ -f "$STANDARDS_FILE" ]] || error "Missing standards file: $STANDARDS_FILE"
+
+ALLOWED_TYPES="$(jq -r '.branch.allowed_types[]' "$STANDARDS_FILE")"
+ALLOWED_TYPES_REGEX="$(jq -r '.branch.allowed_types | join("|")' "$STANDARDS_FILE")"
+TICKET_PATTERN="$(jq -r '.branch.ticket_pattern' "$STANDARDS_FILE")"
+SLUG_PATTERN="$(jq -r '.branch.slug_pattern' "$STANDARDS_FILE")"
+BASH_TICKET_PATTERN="${TICKET_PATTERN//\(\?:/(}"
+BASH_SLUG_PATTERN="${SLUG_PATTERN//\(\?:/(}"
+
+if [[ -n "$BRANCH" ]]; then
+  [[ -z "$TYPE" && -z "$SLUG" && -z "$TICKET" ]] || \
+    error "Use either --branch OR --type/--slug/--ticket, not both."
+else
+  [[ -n "$TYPE" ]] || error "--type is required when --branch is not provided."
+  [[ -n "$SLUG" ]] || error "--slug is required when --branch is not provided."
+
+  contains_type "$TYPE" || error "Unsupported --type '$TYPE'."
+  [[ "$SLUG" =~ ^${BASH_SLUG_PATTERN}$ ]] || error "Slug '$SLUG' does not match slug policy."
+
+  if [[ -n "$TICKET" ]]; then
+    [[ "$TICKET" =~ ^${BASH_TICKET_PATTERN}$ ]] || error "Ticket '$TICKET' does not match ticket policy."
+    BRANCH="${TYPE}/${TICKET}-${SLUG}"
+  else
+    BRANCH="${TYPE}/${SLUG}"
+  fi
+fi
+
+validate_branch "$BRANCH"
+
+BASE_REF=""
+if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/${BASE_BRANCH}"; then
+  BASE_REF="$BASE_BRANCH"
+elif git -C "$REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/${BASE_BRANCH}"; then
+  BASE_REF="origin/${BASE_BRANCH}"
+else
+  info "Fetching origin/${BASE_BRANCH} to resolve base ref."
+  git -C "$REPO_ROOT" fetch origin "$BASE_BRANCH" >/dev/null
+  if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/${BASE_BRANCH}"; then
+    BASE_REF="origin/${BASE_BRANCH}"
+  else
+    error "Unable to resolve base branch '${BASE_BRANCH}'."
+  fi
+fi
+
+if [[ -z "$WORKTREE_PATH" ]]; then
+  repo_name="$(basename "$REPO_ROOT")"
+  WORKTREE_PATH="$(dirname "$REPO_ROOT")/${repo_name}-${BRANCH//\//-}"
+fi
+
+worktree_parent="$(cd -- "$(dirname -- "$WORKTREE_PATH")" && pwd)"
+WORKTREE_PATH="${worktree_parent}/$(basename -- "$WORKTREE_PATH")"
+
+[[ ! -e "$WORKTREE_PATH" ]] || error "Worktree path already exists: $WORKTREE_PATH"
+
+LOCAL_EXISTS=0
+REMOTE_EXISTS=0
+git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/${BRANCH}" && LOCAL_EXISTS=1 || true
+git -C "$REPO_ROOT" ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1 && REMOTE_EXISTS=1 || true
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  if [[ "$LOCAL_EXISTS" -eq 1 ]]; then
+    echo "[DRY] git -C \"$REPO_ROOT\" worktree add \"$WORKTREE_PATH\" \"$BRANCH\""
+  elif [[ "$REMOTE_EXISTS" -eq 1 ]]; then
+    echo "[DRY] git -C \"$REPO_ROOT\" worktree add --track -b \"$BRANCH\" \"$WORKTREE_PATH\" \"origin/$BRANCH\""
+  else
+    echo "[DRY] git -C \"$REPO_ROOT\" worktree add -b \"$BRANCH\" \"$WORKTREE_PATH\" \"$BASE_REF\""
+  fi
+  exit 0
+fi
+
+if [[ "$LOCAL_EXISTS" -eq 1 ]]; then
+  git -C "$REPO_ROOT" worktree add "$WORKTREE_PATH" "$BRANCH"
+elif [[ "$REMOTE_EXISTS" -eq 1 ]]; then
+  git -C "$REPO_ROOT" worktree add --track -b "$BRANCH" "$WORKTREE_PATH" "origin/$BRANCH"
+else
+  git -C "$REPO_ROOT" worktree add -b "$BRANCH" "$WORKTREE_PATH" "$BASE_REF"
+fi
+
+echo "[OK] Branch: $BRANCH"
+echo "[OK] Worktree: $WORKTREE_PATH"

--- a/.harmony/agency/_ops/scripts/sync-github-labels.sh
+++ b/.harmony/agency/_ops/scripts/sync-github-labels.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO=""
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  sync-github-labels.sh [--repo <owner/repo>] [--dry-run]
+
+Synchronizes the autonomy label catalog used by PR triage/policy workflows.
+Creates missing labels and updates existing label color/description idempotently.
+USAGE
+}
+
+error() {
+  echo "[ERROR] $1" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || error "Missing required command: $cmd"
+}
+
+repo_from_origin() {
+  local remote
+  remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+  if [[ -z "$remote" ]]; then
+    return 1
+  fi
+
+  if [[ "$remote" =~ ^https?://github\.com/([^/]+)/([^/]+)\.git$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return 0
+  fi
+
+  if [[ "$remote" =~ ^https?://github\.com/([^/]+)/([^/]+)$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return 0
+  fi
+
+  if [[ "$remote" =~ ^git@github\.com:([^/]+)/([^/]+)\.git$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return 0
+  fi
+
+  if [[ "$remote" =~ ^git@github\.com:([^/]+)/([^/]+)$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return 0
+  fi
+
+  return 1
+}
+
+sync_label() {
+  local repo="$1"
+  local name="$2"
+  local color="$3"
+  local description="$4"
+  local encoded
+
+  encoded="$(jq -rn --arg name "$name" '$name | @uri')"
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] sync label '$name' (color=$color)"
+    return 0
+  fi
+
+  if gh api "repos/${repo}/labels/${encoded}" >/dev/null 2>&1; then
+    gh api \
+      --method PATCH \
+      "repos/${repo}/labels/${encoded}" \
+      -f new_name="$name" \
+      -f color="$color" \
+      -f description="$description" >/dev/null
+    echo "[OK] updated label: $name"
+  else
+    gh api \
+      --method POST \
+      "repos/${repo}/labels" \
+      -f name="$name" \
+      -f color="$color" \
+      -f description="$description" >/dev/null
+    echo "[OK] created label: $name"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      shift
+      [[ $# -gt 0 ]] || error "--repo requires a value"
+      REPO="$1"
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      error "Unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+require_cmd gh
+require_cmd jq
+require_cmd git
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(repo_from_origin || true)"
+fi
+[[ -n "$REPO" ]] || error "Unable to infer repository. Pass --repo <owner/repo>."
+
+while IFS='|' read -r name color description; do
+  [[ -n "$name" ]] || continue
+  sync_label "$REPO" "$name" "$color" "$description"
+done <<'EOF'
+type:feat|1D76DB|New feature
+type:fix|D73A4A|Bug fix
+type:refactor|A2EEEF|Refactor
+type:perf|C2E0C6|Performance improvement
+type:test|FBCA04|Tests
+type:docs|0075CA|Documentation
+type:chore|C5DEF5|Maintenance and chores
+type:ci|5319E7|CI or automation
+type:revert|BFD4F2|Revert change
+type:unknown|D4C5F9|Unclassified branch type
+area:agency|0E8A16|Harmony agency domain
+area:capabilities|0E8A16|Harmony capabilities domain
+area:cognition|0E8A16|Harmony cognition domain
+area:orchestration|0E8A16|Harmony orchestration domain
+area:scaffolding|0E8A16|Harmony scaffolding domain
+area:assurance|0E8A16|Harmony assurance domain
+area:engine|0E8A16|Harmony engine domain
+area:continuity|0E8A16|Harmony continuity domain
+area:ideation|0E8A16|Harmony ideation domain
+area:output|0E8A16|Harmony output domain
+area:github|0052CC|GitHub workflow or settings surface
+area:root|0052CC|Root contract or repository surface
+area:uncategorized|BFDADC|No known area match
+risk:low|D4C5F9|Low risk routine change
+risk:med|FBCA04|Medium risk change
+risk:high|B60205|High impact governance/control-plane change
+accept:human|000000|Explicit human acceptance for high-impact merge
+autonomy:auto-merge|1B8835|Eligible for autonomous auto-merge lane
+autonomy:no-automerge|B60205|Excluded from autonomous auto-merge lane
+bot:dependabot|0366D6|Dependabot pull request
+EOF
+
+echo "[OK] Label sync complete for ${REPO}"
+

--- a/.harmony/agency/practices/README.md
+++ b/.harmony/agency/practices/README.md
@@ -7,5 +7,6 @@
 - [Clean-Break Migrations (Agent Instructions)](clean-break-migration.instructions.md)
 - [Commits - Convention and Discipline](commits.md)
 - [Pull Requests - Convention and Quality Standards](pull-request-standards.md)
+- [Git Autonomy Playbook](git-autonomy-playbook.md)
 - [GitHub Autonomy Runbook](github-autonomy-runbook.md)
 - [Commit and PR Standards (Machine Contract)](standards/commit-pr-standards.json)

--- a/.harmony/agency/practices/git-autonomy-playbook.md
+++ b/.harmony/agency/practices/git-autonomy-playbook.md
@@ -1,0 +1,118 @@
+---
+title: Git Autonomy Playbook
+description: Local operator playbook for autonomy-first Git and GitHub workflow execution.
+---
+
+# Git Autonomy Playbook
+
+This playbook covers the local script lane for autonomy-first Git/GitHub flow:
+
+- `.harmony/agency/_ops/scripts/git-wt-new.sh`
+- `.harmony/agency/_ops/scripts/git-pr-open.sh`
+- `.harmony/agency/_ops/scripts/git-pr-ship.sh`
+- `.harmony/agency/_ops/scripts/sync-github-labels.sh`
+
+Use this with [GitHub Autonomy Runbook](./github-autonomy-runbook.md) for token,
+permissions, and control-plane drift operations.
+
+---
+
+## Preconditions
+
+- `gh auth status` is healthy for the target account.
+- Branch naming and commit conventions remain governed by:
+  - `.harmony/agency/practices/standards/commit-pr-standards.json`
+- Repository autonomy variables/secrets are configured:
+  - `AUTONOMY_AUTO_MERGE_ENABLED=true`
+  - `AUTONOMY_PAT` repository Actions secret
+
+---
+
+## Script Quick Reference
+
+### 1) Create a branch + worktree
+
+```bash
+.harmony/agency/_ops/scripts/git-wt-new.sh \
+  --type fix \
+  --slug phase-e-local-autonomy-scripts
+```
+
+Behavior:
+
+- Validates branch format against repository branch policy contract.
+- Creates a new worktree in a sibling folder.
+- Creates branch from `main` (or `--base` override).
+
+### 2) Commit, push, and open a draft PR
+
+```bash
+.harmony/agency/_ops/scripts/git-pr-open.sh \
+  --title "fix(github): tighten autonomy script defaults" \
+  --summary "Adds safer defaults for local autonomy helper scripts." \
+  --stage-all \
+  --no-issue "operator-tooling"
+```
+
+Behavior:
+
+- Commits staged changes, or stages everything when `--stage-all` is set.
+- Pushes the current branch to `origin`.
+- Builds PR body from `.github/PULL_REQUEST_TEMPLATE.md`.
+- Ensures issue-link policy with either `Closes #...` or `No-Issue: ...`.
+
+### 3) Label, ready, and request auto-merge
+
+```bash
+.harmony/agency/_ops/scripts/git-pr-ship.sh --accept-human
+```
+
+Behavior:
+
+- Adds autonomy lane labels (`autonomy:auto-merge` by default).
+- Removes `autonomy:no-automerge` when requesting autonomous lane.
+- Marks draft PR as ready (unless `--no-ready`).
+- Requests squash auto-merge (unless `--no-automerge`).
+
+### 4) Sync required GitHub labels
+
+```bash
+.harmony/agency/_ops/scripts/sync-github-labels.sh
+```
+
+Behavior:
+
+- Creates or updates triage/policy labels idempotently.
+- Keeps color/description aligned with workflow expectations.
+
+---
+
+## Lane Guidance
+
+### Low-risk autonomous lane
+
+1. Create worktree/branch with `git-wt-new.sh`.
+2. Implement change.
+3. Open draft PR with `git-pr-open.sh`.
+4. Mark ready + request merge with `git-pr-ship.sh`.
+5. Let required checks and branch rules enforce final merge safety.
+
+### High-impact guarded lane
+
+When touching high-impact paths (for example `.github/` or governance paths):
+
+1. Add `accept:human` before merge.
+2. Keep PR focused and explicitly document risk/rollback.
+3. Use `git-pr-ship.sh --accept-human` to preserve metadata-level check-in.
+
+---
+
+## Safety and Exceptions
+
+- Do not bypass required checks or branch rules via local scripts.
+- Keep `main` PR-first; direct push remains break-glass only.
+- If autonomy behavior regresses:
+  1. Set `AUTONOMY_AUTO_MERGE_ENABLED=false`
+  2. Keep triage/policy checks active
+  3. Follow rollback guidance in
+     [GitHub Autonomy Runbook](./github-autonomy-runbook.md).


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Adds Section 4.E local autonomy tooling: four Harmony-native helper scripts under
`.harmony/agency/_ops/scripts/` plus a new operator playbook in agency
practices, and links the playbook from practices index.

## Why

This implements the next rollout step after Phase D by giving solo developers a
low-friction local path to create compliant branches/worktrees, open template-
compliant PRs, ship PR metadata/auto-merge requests, and keep label catalog
aligned with triage/policy workflows.
No-Issue: phase-e-local-autonomy-tooling

## How

- Added `git-wt-new.sh` to create policy-compliant branch + worktree from the
  commit/branch standards contract.
- Added `git-pr-open.sh` to validate conventional title/commit inputs, generate
  PR body from canonical template, enforce issue-link policy, and open a PR.
- Added `git-pr-ship.sh` to apply autonomy labels, mark draft ready, and request
  squash auto-merge.
- Added `sync-github-labels.sh` to idempotently create/update the label set used
  by PR triage and autonomy policy workflows.
- Added `git-autonomy-playbook.md` and linked it in practices README.

## Tradeoffs

`git-pr-open.sh` now defaults to committing only staged changes to avoid
accidental inclusion of unrelated untracked files; users must pass `--stage-all`
when they intentionally want all workspace changes included.

## Testing

- `bash -n` validation for all new scripts.
- `--help` execution checks for each script.
- Dry-run checks:
  - `git-wt-new.sh --dry-run`
  - `git-pr-open.sh --dry-run`
  - `sync-github-labels.sh --dry-run`
- Existing alignment validation:
  - `.harmony/assurance/runtime/_ops/scripts/validate-commit-pr-alignment.sh`

## Rollout

n/a (tooling and documentation only). Scripts are opt-in and do not change
existing CI required checks or branch rules.

## Risk Rubric

- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High
- Rollback plan: revert commit `843f4b5d`.
- Flags changed (name, owner, expiry, rollout): none.

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none.
- Threat model update/link: n/a.

## Observability and Performance

- Traces/logs/metrics for changed flows: n/a (local helper scripts only).
- Representative traces for high risk changes: n/a.
- Performance or bundle impact: negligible.

## License and Provenance

- New dependencies and licenses: none.
- Generated code/templates provenance notes: none.

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

No UI changes.
