### PR TITLE
ci(github): enforce clean-state lifecycle after pr closure

### DIFF
--- a/.github/workflows/pr-clean-state-enforcer.yml
+++ b/.github/workflows/pr-clean-state-enforcer.yml
@@ -1,0 +1,245 @@
+name: PR Clean State Enforcer
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+      - edited
+      - labeled
+      - unlabeled
+      - closed
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  enforce-clean-state:
+    name: enforce-clean-state
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      ATTENTION_AFTER_HOURS: ${{ vars.AUTONOMY_ATTENTION_AFTER_HOURS || '4' }}
+    steps:
+      - name: Enforce clean-state contracts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const defaultBranch = context.payload.repository?.default_branch || "main";
+            const attentionAfterHours = Number.parseInt(process.env.ATTENTION_AFTER_HOURS || "4", 10);
+
+            const attentionLabel = "autonomy:attention-required";
+            const healthLabel = "ops:autonomy-health";
+            const attentionIssueTitle = "[autonomy-health] open-pr attention required";
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color,
+                  description
+                });
+              }
+            }
+
+            await ensureLabel(attentionLabel, "D93F0B", "PR requires prompt human action to maintain clean-state flow");
+            await ensureLabel(healthLabel, "B60205", "Automation and autonomy health signal");
+
+            const openPulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+
+            const openHeadRefs = new Set(
+              openPulls
+                .filter((pr) => pr.head?.repo?.full_name === `${owner}/${repo}`)
+                .map((pr) => pr.head?.ref)
+                .filter(Boolean)
+            );
+
+            const attentionRows = [];
+            let labelsAdded = 0;
+            let labelsRemoved = 0;
+            let deletedHeadRefs = 0;
+
+            const blockedMergeStates = new Set(["blocked", "behind", "dirty", "unknown", "unstable"]);
+
+            for (const pr of openPulls) {
+              const labels = new Set((pr.labels || []).map((label) => label.name));
+              const reasons = [];
+              const ageHours = (Date.now() - Date.parse(pr.updated_at)) / (1000 * 60 * 60);
+
+              if (labels.has("accept:human")) {
+                reasons.push("awaiting human acceptance");
+              }
+              if (labels.has("autonomy:no-automerge")) {
+                reasons.push("autonomy lane disabled");
+              }
+
+              let mergeState = "unknown";
+              try {
+                const detail = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pr.number
+                });
+                mergeState = String(detail.data.mergeable_state || "unknown").toLowerCase();
+              } catch (error) {
+                core.warning(`Could not read merge state for PR #${pr.number}: ${error.message}`);
+              }
+
+              if (blockedMergeStates.has(mergeState)) {
+                reasons.push(`merge state is '${mergeState}'`);
+              }
+
+              const needsAttention = reasons.length > 0 && ageHours >= attentionAfterHours;
+
+              if (needsAttention) {
+                attentionRows.push({
+                  number: pr.number,
+                  url: pr.html_url,
+                  title: pr.title,
+                  ageHours: Math.floor(ageHours),
+                  reasons
+                });
+                if (!labels.has(attentionLabel)) {
+                  try {
+                    await github.rest.issues.addLabels({
+                      owner,
+                      repo,
+                      issue_number: pr.number,
+                      labels: [attentionLabel]
+                    });
+                    labelsAdded += 1;
+                  } catch (error) {
+                    core.warning(`Could not add ${attentionLabel} to PR #${pr.number}: ${error.message}`);
+                  }
+                }
+              } else if (labels.has(attentionLabel)) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    name: attentionLabel
+                  });
+                  labelsRemoved += 1;
+                } catch (error) {
+                  core.warning(`Could not remove ${attentionLabel} from PR #${pr.number}: ${error.message}`);
+                }
+              }
+            }
+
+            const closedPulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "closed",
+              sort: "updated",
+              direction: "desc",
+              per_page: 100
+            });
+
+            for (const pr of closedPulls) {
+              const sameRepoHead = pr.head?.repo?.full_name === `${owner}/${repo}`;
+              const headRef = pr.head?.ref || "";
+              if (!sameRepoHead || !headRef) continue;
+              if (headRef === defaultBranch || headRef === "main") continue;
+              if (openHeadRefs.has(headRef)) continue;
+
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `heads/${headRef}`
+                });
+                deletedHeadRefs += 1;
+              } catch (error) {
+                if (error.status !== 422 && error.status !== 404) {
+                  core.warning(`Could not delete closed head ref '${headRef}': ${error.message}`);
+                }
+              }
+            }
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              labels: healthLabel,
+              per_page: 100
+            });
+            const attentionIssue = openIssues.find((issue) => !issue.pull_request && issue.title === attentionIssueTitle);
+
+            if (attentionRows.length > 0) {
+              const lines = [
+                "Clean-state enforcer detected open PRs requiring prompt action.",
+                "",
+                `- Attention threshold: ${attentionAfterHours}h since last update`,
+                `- Generated at: ${new Date().toISOString()}`,
+                "",
+                "| PR | Age (h) | Reasons |",
+                "| --- | ---: | --- |",
+                ...attentionRows.map((row) => `| [#${row.number}](${row.url}) | ${row.ageHours} | ${row.reasons.join("; ")} |`),
+                "",
+                "Action expectations:",
+                "- Resolve manual-lane/blocking conditions promptly (`accept:human`, policy labels, review threads/checks).",
+                "- After merge/close, run local cleanup: `.harmony/agency/_ops/scripts/git-pr-cleanup.sh`.",
+                "- Preferred shipping path: `.harmony/agency/_ops/scripts/git-pr-ship.sh` (includes cleanup watcher)."
+              ];
+              const body = lines.join("\n");
+
+              if (attentionIssue) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: attentionIssue.number,
+                  body
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title: attentionIssueTitle,
+                  body,
+                  labels: [healthLabel]
+                });
+              }
+            } else if (attentionIssue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: attentionIssue.number,
+                body: "Clean-state enforcer is healthy: no open PRs currently require attention."
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: attentionIssue.number,
+                state: "closed"
+              });
+            }
+
+            await core.summary
+              .addHeading("PR Clean State Enforcer")
+              .addRaw(`- open PRs scanned: ${openPulls.length}\n`)
+              .addRaw(`- attention PRs: ${attentionRows.length}\n`)
+              .addRaw(`- attention labels added: ${labelsAdded}\n`)
+              .addRaw(`- attention labels removed: ${labelsRemoved}\n`)
+              .addRaw(`- closed head refs deleted: ${deletedHeadRefs}\n`)
+              .write();

--- a/.github/workflows/pr-clean-state-enforcer.yml
+++ b/.github/workflows/pr-clean-state-enforcer.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 

--- a/.harmony/agency/_ops/scripts/git-pr-cleanup.sh
+++ b/.harmony/agency/_ops/scripts/git-pr-cleanup.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PR_NUMBER=""
+TARGET_BRANCH=""
+WATCH_PR_NUMBER=""
+WATCH_TIMEOUT_SECONDS=86400
+SYNC_MAIN=1
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  git-pr-cleanup.sh [--pr <number>] [--branch <name>] [options]
+  git-pr-cleanup.sh --watch-pr <number> [--watch-timeout-seconds <seconds>] [options]
+
+Options:
+  --pr <number>                  Cleanup branch state for a closed PR.
+  --branch <name>                Cleanup a specific branch if its latest PR is not open.
+  --watch-pr <number>            Poll until PR closes, then run cleanup for that PR.
+  --watch-timeout-seconds <n>    Max wait when using --watch-pr (default: 86400).
+  --no-sync-main                 Do not checkout/sync main after cleanup.
+  --dry-run                      Print actions without mutating local/remote state.
+
+Default mode (no --pr/--branch):
+  Sweep local branches and remove branches whose latest PR is closed/merged.
+USAGE
+}
+
+error() {
+  echo "[ERROR] $1" >&2
+  exit 1
+}
+
+info() {
+  echo "[INFO] $1"
+}
+
+warn() {
+  echo "[WARN] $1"
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || error "Missing required command: $cmd"
+}
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || true
+}
+
+run_cmd() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] $*"
+    return 0
+  fi
+  "$@"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      shift
+      [[ $# -gt 0 ]] || error "--pr requires a value"
+      PR_NUMBER="$1"
+      ;;
+    --branch)
+      shift
+      [[ $# -gt 0 ]] || error "--branch requires a value"
+      TARGET_BRANCH="$1"
+      ;;
+    --watch-pr)
+      shift
+      [[ $# -gt 0 ]] || error "--watch-pr requires a value"
+      WATCH_PR_NUMBER="$1"
+      ;;
+    --watch-timeout-seconds)
+      shift
+      [[ $# -gt 0 ]] || error "--watch-timeout-seconds requires a value"
+      WATCH_TIMEOUT_SECONDS="$1"
+      ;;
+    --no-sync-main)
+      SYNC_MAIN=0
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      error "Unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+if [[ -n "$PR_NUMBER" && -n "$TARGET_BRANCH" ]]; then
+  error "Use either --pr or --branch, not both."
+fi
+
+if [[ -n "$WATCH_PR_NUMBER" && ( -n "$PR_NUMBER" || -n "$TARGET_BRANCH" ) ]]; then
+  error "--watch-pr cannot be combined with --pr/--branch."
+fi
+
+require_cmd git
+require_cmd gh
+require_cmd jq
+
+REPO_ROOT="$(repo_root)"
+[[ -n "$REPO_ROOT" ]] || error "Run this command from inside a git repository."
+
+if [[ -n "$WATCH_PR_NUMBER" ]]; then
+  [[ "$WATCH_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || error "--watch-timeout-seconds must be a positive integer."
+
+  info "Watching PR #${WATCH_PR_NUMBER} for closure (timeout=${WATCH_TIMEOUT_SECONDS}s)."
+  start_epoch="$(date +%s)"
+  while true; do
+    PR_PAYLOAD="$(gh pr view "$WATCH_PR_NUMBER" --json state,url 2>/dev/null || true)"
+    [[ -n "$PR_PAYLOAD" ]] || {
+      sleep 15
+      continue
+    }
+
+    PR_STATE="$(jq -r '.state' <<<"$PR_PAYLOAD")"
+    PR_URL="$(jq -r '.url' <<<"$PR_PAYLOAD")"
+    if [[ "$PR_STATE" != "OPEN" ]]; then
+      info "Observed PR closure for #${WATCH_PR_NUMBER} (${PR_URL})."
+      PR_NUMBER="$WATCH_PR_NUMBER"
+      break
+    fi
+
+    now_epoch="$(date +%s)"
+    elapsed="$((now_epoch - start_epoch))"
+    if (( elapsed >= WATCH_TIMEOUT_SECONDS )); then
+      warn "Timeout while waiting for PR #${WATCH_PR_NUMBER} to close."
+      exit 0
+    fi
+    sleep 15
+  done
+fi
+
+CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+
+ensure_checkout_safe() {
+  if ! git -C "$REPO_ROOT" diff --quiet || ! git -C "$REPO_ROOT" diff --cached --quiet; then
+    error "Working tree is not clean; cannot switch branches for cleanup."
+  fi
+}
+
+add_candidate() {
+  local branch="$1"
+  [[ -n "$branch" ]] || return 0
+  [[ "$branch" == "main" ]] && return 0
+  for existing in "${CANDIDATES[@]}"; do
+    [[ "$existing" == "$branch" ]] && return 0
+  done
+  CANDIDATES+=("$branch")
+}
+
+info "Fetching and pruning origin refs."
+run_cmd git -C "$REPO_ROOT" fetch --prune origin
+
+PR_INDEX="$(gh pr list --state all --limit 200 --json number,state,headRefName,baseRefName,url,updatedAt)"
+
+CANDIDATES=()
+TARGET_BASE_BRANCH="main"
+
+if [[ -n "$PR_NUMBER" ]]; then
+  PR_JSON="$(gh pr view "$PR_NUMBER" --json number,state,headRefName,baseRefName,url 2>/dev/null || true)"
+  [[ -n "$PR_JSON" ]] || error "Unable to load PR #${PR_NUMBER}."
+  PR_STATE="$(jq -r '.state' <<<"$PR_JSON")"
+  if [[ "$PR_STATE" == "OPEN" ]]; then
+    error "PR #${PR_NUMBER} is still open; cleanup runs after closure."
+  fi
+  add_candidate "$(jq -r '.headRefName' <<<"$PR_JSON")"
+  TARGET_BASE_BRANCH="$(jq -r '.baseRefName // "main"' <<<"$PR_JSON")"
+elif [[ -n "$TARGET_BRANCH" ]]; then
+  BRANCH_PR_JSON="$(jq -c --arg branch "$TARGET_BRANCH" '[.[] | select(.headRefName == $branch)] | sort_by(.number) | last // empty' <<<"$PR_INDEX")"
+  if [[ -z "$BRANCH_PR_JSON" ]]; then
+    warn "No PR found for branch '$TARGET_BRANCH'; cleaning local/remote refs if present."
+    add_candidate "$TARGET_BRANCH"
+  else
+    BRANCH_PR_STATE="$(jq -r '.state' <<<"$BRANCH_PR_JSON")"
+    if [[ "$BRANCH_PR_STATE" == "OPEN" ]]; then
+      error "Latest PR for branch '$TARGET_BRANCH' is still open."
+    fi
+    add_candidate "$TARGET_BRANCH"
+    TARGET_BASE_BRANCH="$(jq -r '.baseRefName // "main"' <<<"$BRANCH_PR_JSON")"
+  fi
+else
+  mapfile -t LOCAL_BRANCHES < <(git -C "$REPO_ROOT" for-each-ref refs/heads --format='%(refname:short)' | grep -v '^main$' || true)
+  for branch in "${LOCAL_BRANCHES[@]}"; do
+    if [[ "$branch" == "$CURRENT_BRANCH" ]]; then
+      continue
+    fi
+
+    branch_pr_json="$(jq -c --arg branch "$branch" '[.[] | select(.headRefName == $branch)] | sort_by(.number) | last // empty' <<<"$PR_INDEX")"
+    if [[ -n "$branch_pr_json" ]]; then
+      branch_pr_state="$(jq -r '.state' <<<"$branch_pr_json")"
+      if [[ "$branch_pr_state" != "OPEN" ]]; then
+        add_candidate "$branch"
+      fi
+      continue
+    fi
+
+    if git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "origin/main" >/dev/null 2>&1; then
+      add_candidate "$branch"
+      continue
+    fi
+
+    upstream_ref="$(git -C "$REPO_ROOT" for-each-ref "refs/heads/${branch}" --format='%(upstream:short)')"
+    if [[ -n "$upstream_ref" ]] && ! git -C "$REPO_ROOT" show-ref --verify --quiet "refs/remotes/${upstream_ref}"; then
+      add_candidate "$branch"
+    fi
+  done
+fi
+
+deleted_local=0
+deleted_remote=0
+skipped_open=0
+
+for branch in "${CANDIDATES[@]}"; do
+  [[ "$branch" == "main" ]] && continue
+
+  open_count="$(gh pr list --state open --head "$branch" --limit 1 --json number | jq 'length')"
+  if [[ "$open_count" != "0" ]]; then
+    skipped_open=$((skipped_open + 1))
+    continue
+  fi
+
+  if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+    ensure_checkout_safe
+    if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/${TARGET_BASE_BRANCH}"; then
+      run_cmd git -C "$REPO_ROOT" checkout "$TARGET_BASE_BRANCH"
+      CURRENT_BRANCH="$TARGET_BASE_BRANCH"
+    else
+      run_cmd git -C "$REPO_ROOT" checkout main
+      CURRENT_BRANCH="main"
+    fi
+  fi
+
+  if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/${branch}"; then
+    run_cmd git -C "$REPO_ROOT" branch -D "$branch"
+    deleted_local=$((deleted_local + 1))
+  fi
+
+  if git -C "$REPO_ROOT" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    run_cmd git -C "$REPO_ROOT" push origin --delete "$branch"
+    deleted_remote=$((deleted_remote + 1))
+  fi
+done
+
+if [[ "$SYNC_MAIN" -eq 1 ]]; then
+  if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    ensure_checkout_safe
+    run_cmd git -C "$REPO_ROOT" checkout main
+    CURRENT_BRANCH="main"
+  fi
+
+  if ! git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/main"; then
+    run_cmd git -C "$REPO_ROOT" checkout -b main origin/main
+    CURRENT_BRANCH="main"
+  else
+    run_cmd git -C "$REPO_ROOT" merge --ff-only origin/main
+  fi
+fi
+
+run_cmd git -C "$REPO_ROOT" fetch --prune origin
+
+echo "[OK] Local branches deleted: ${deleted_local}"
+echo "[OK] Remote branches deleted: ${deleted_remote}"
+echo "[OK] Skipped due to open PR: ${skipped_open}"
+echo "[OK] Current branch: ${CURRENT_BRANCH}"

--- a/.harmony/agency/_ops/scripts/git-pr-ship.sh
+++ b/.harmony/agency/_ops/scripts/git-pr-ship.sh
@@ -8,6 +8,10 @@ REQUEST_AUTOMERGE=1
 ADD_AUTO_LABEL=1
 DRY_RUN=0
 LABELS_CSV=""
+WAIT_FOR_CLOSE=1
+WAIT_TIMEOUT_SECONDS=1800
+RUN_CLEANUP=1
+BACKGROUND_WATCH_TIMEOUT_SECONDS=86400
 
 usage() {
   cat <<'USAGE'
@@ -20,6 +24,9 @@ Options:
   --no-ready             Do not convert draft PR to ready state.
   --no-auto-label        Do not add autonomy:auto-merge.
   --no-automerge         Skip auto-merge request call.
+  --no-wait              Do not block waiting for PR closure.
+  --wait-timeout-seconds Seconds to wait for closure before background watcher (default: 1800).
+  --no-cleanup           Do not run local cleanup after PR closure.
   --dry-run              Print actions without mutating PR state.
 
 Default behavior:
@@ -36,6 +43,10 @@ error() {
 
 info() {
   echo "[INFO] $1"
+}
+
+warn() {
+  echo "[WARN] $1"
 }
 
 require_cmd() {
@@ -71,6 +82,17 @@ while [[ $# -gt 0 ]]; do
     --no-automerge)
       REQUEST_AUTOMERGE=0
       ;;
+    --no-wait)
+      WAIT_FOR_CLOSE=0
+      ;;
+    --wait-timeout-seconds)
+      shift
+      [[ $# -gt 0 ]] || error "--wait-timeout-seconds requires a value"
+      WAIT_TIMEOUT_SECONDS="$1"
+      ;;
+    --no-cleanup)
+      RUN_CLEANUP=0
+      ;;
     --dry-run)
       DRY_RUN=1
       ;;
@@ -87,6 +109,32 @@ done
 
 require_cmd gh
 require_cmd jq
+
+[[ "$WAIT_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || error "--wait-timeout-seconds must be a positive integer."
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CLEANUP_SCRIPT="${SCRIPT_DIR}/git-pr-cleanup.sh"
+
+launch_background_watcher() {
+  local reason="$1"
+  local watcher_log="${TMPDIR:-/tmp}/harmony-pr-cleanup-${PR_NUMBER}.log"
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY] nohup \"$CLEANUP_SCRIPT\" --watch-pr \"$PR_NUMBER\" --watch-timeout-seconds \"$BACKGROUND_WATCH_TIMEOUT_SECONDS\" >\"$watcher_log\" 2>&1 &"
+    return 0
+  fi
+
+  if [[ ! -x "$CLEANUP_SCRIPT" ]]; then
+    warn "Cleanup script is not executable: $CLEANUP_SCRIPT"
+    return 0
+  fi
+
+  nohup "$CLEANUP_SCRIPT" \
+    --watch-pr "$PR_NUMBER" \
+    --watch-timeout-seconds "$BACKGROUND_WATCH_TIMEOUT_SECONDS" \
+    >"$watcher_log" 2>&1 &
+  info "Started background cleanup watcher (pid=$!, reason=$reason, log=$watcher_log)."
+}
 
 if [[ -z "$PR_NUMBER" ]]; then
   PR_NUMBER="$(gh pr view --json number --jq '.number' 2>/dev/null || true)"
@@ -155,5 +203,38 @@ if [[ "$REQUEST_AUTOMERGE" -eq 1 ]]; then
   fi
 fi
 
-echo "[OK] PR ready for autonomy lane: $PR_URL"
+if [[ "$RUN_CLEANUP" -eq 1 ]]; then
+  if [[ "$REQUEST_AUTOMERGE" -eq 1 && "$WAIT_FOR_CLOSE" -eq 1 ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY] wait for PR closure (timeout=${WAIT_TIMEOUT_SECONDS}s), then run \"$CLEANUP_SCRIPT\" --pr \"$PR_NUMBER\""
+    else
+      info "Waiting for PR #${PR_NUMBER} to close (timeout=${WAIT_TIMEOUT_SECONDS}s)."
+      start_epoch="$(date +%s)"
+      while true; do
+        PR_STATUS_PAYLOAD="$(gh pr view "$PR_NUMBER" --json state,url 2>/dev/null || true)"
+        if [[ -n "$PR_STATUS_PAYLOAD" ]]; then
+          current_state="$(jq -r '.state' <<<"$PR_STATUS_PAYLOAD")"
+          if [[ "$current_state" != "OPEN" ]]; then
+            info "PR #${PR_NUMBER} is now ${current_state}; running local cleanup."
+            [[ -x "$CLEANUP_SCRIPT" ]] || error "Cleanup script is missing or not executable: $CLEANUP_SCRIPT"
+            "$CLEANUP_SCRIPT" --pr "$PR_NUMBER"
+            break
+          fi
+        fi
 
+        now_epoch="$(date +%s)"
+        elapsed="$((now_epoch - start_epoch))"
+        if (( elapsed >= WAIT_TIMEOUT_SECONDS )); then
+          warn "PR #${PR_NUMBER} is still open after ${WAIT_TIMEOUT_SECONDS}s."
+          launch_background_watcher "wait-timeout"
+          break
+        fi
+        sleep 10
+      done
+    fi
+  elif [[ "$REQUEST_AUTOMERGE" -eq 0 ]]; then
+    launch_background_watcher "manual-lane"
+  fi
+fi
+
+echo "[OK] PR ready for autonomy lane: $PR_URL"

--- a/.harmony/agency/_ops/scripts/git-pr-ship.sh
+++ b/.harmony/agency/_ops/scripts/git-pr-ship.sh
@@ -232,6 +232,8 @@ if [[ "$RUN_CLEANUP" -eq 1 ]]; then
         sleep 10
       done
     fi
+  elif [[ "$REQUEST_AUTOMERGE" -eq 1 && "$WAIT_FOR_CLOSE" -eq 0 ]]; then
+    launch_background_watcher "no-wait"
   elif [[ "$REQUEST_AUTOMERGE" -eq 0 ]]; then
     launch_background_watcher "manual-lane"
   fi

--- a/.harmony/agency/_ops/scripts/git-wt-new.sh
+++ b/.harmony/agency/_ops/scripts/git-wt-new.sh
@@ -8,12 +8,13 @@ TICKET=""
 BRANCH=""
 WORKTREE_PATH=""
 DRY_RUN=0
+RUN_CLEANUP_PREFLIGHT=1
 
 usage() {
   cat <<'USAGE'
 Usage:
-  git-wt-new.sh --type <type> --slug <slug> [--ticket <ABC-123>] [--base <branch>] [--worktree <path>] [--dry-run]
-  git-wt-new.sh --branch <type/slug-or-ticket-slug> [--base <branch>] [--worktree <path>] [--dry-run]
+  git-wt-new.sh --type <type> --slug <slug> [--ticket <ABC-123>] [--base <branch>] [--worktree <path>] [--no-cleanup-preflight] [--dry-run]
+  git-wt-new.sh --branch <type/slug-or-ticket-slug> [--base <branch>] [--worktree <path>] [--no-cleanup-preflight] [--dry-run]
 
 Creates a new git worktree and branch using repository branch naming standards.
 USAGE
@@ -92,6 +93,9 @@ while [[ $# -gt 0 ]]; do
     --dry-run)
       DRY_RUN=1
       ;;
+    --no-cleanup-preflight)
+      RUN_CLEANUP_PREFLIGHT=0
+      ;;
     -h|--help)
       usage
       exit 0
@@ -111,6 +115,21 @@ REPO_ROOT="$(repo_root)"
 
 STANDARDS_FILE="$REPO_ROOT/.harmony/agency/practices/standards/commit-pr-standards.json"
 [[ -f "$STANDARDS_FILE" ]] || error "Missing standards file: $STANDARDS_FILE"
+
+if [[ "$RUN_CLEANUP_PREFLIGHT" -eq 1 ]]; then
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  CLEANUP_SCRIPT="${SCRIPT_DIR}/git-pr-cleanup.sh"
+  if [[ -x "$CLEANUP_SCRIPT" ]]; then
+    info "Running clean-state preflight before creating new worktree."
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY] \"$CLEANUP_SCRIPT\" --no-sync-main"
+    else
+      "$CLEANUP_SCRIPT" --no-sync-main
+    fi
+  else
+    info "Skipping clean-state preflight (cleanup script not found)."
+  fi
+fi
 
 ALLOWED_TYPES="$(jq -r '.branch.allowed_types[]' "$STANDARDS_FILE")"
 ALLOWED_TYPES_REGEX="$(jq -r '.branch.allowed_types | join("|")' "$STANDARDS_FILE")"

--- a/.harmony/agency/practices/git-autonomy-playbook.md
+++ b/.harmony/agency/practices/git-autonomy-playbook.md
@@ -10,6 +10,7 @@ This playbook covers the local script lane for autonomy-first Git/GitHub flow:
 - `.harmony/agency/_ops/scripts/git-wt-new.sh`
 - `.harmony/agency/_ops/scripts/git-pr-open.sh`
 - `.harmony/agency/_ops/scripts/git-pr-ship.sh`
+- `.harmony/agency/_ops/scripts/git-pr-cleanup.sh`
 - `.harmony/agency/_ops/scripts/sync-github-labels.sh`
 
 Use this with [GitHub Autonomy Runbook](./github-autonomy-runbook.md) for token,
@@ -41,6 +42,7 @@ permissions, and control-plane drift operations.
 Behavior:
 
 - Validates branch format against repository branch policy contract.
+- Runs clean-state preflight (prune/sync/closed-branch cleanup) by default.
 - Creates a new worktree in a sibling folder.
 - Creates branch from `main` (or `--base` override).
 
@@ -73,8 +75,23 @@ Behavior:
 - Removes `autonomy:no-automerge` when requesting autonomous lane.
 - Marks draft PR as ready (unless `--no-ready`).
 - Requests squash auto-merge (unless `--no-automerge`).
+- Waits for PR closure (auto lane) and runs local cleanup enforcement.
+- For manual lanes, starts a background cleanup watcher that runs when the PR closes.
 
-### 4) Sync required GitHub labels
+### 4) Enforce local cleanup state on demand
+
+```bash
+.harmony/agency/_ops/scripts/git-pr-cleanup.sh
+```
+
+Behavior:
+
+- Deletes local branches whose latest PR is already closed/merged.
+- Deletes matching origin branches when no open PR references the branch.
+- Checks out and fast-forwards `main` to `origin/main`.
+- Supports `--watch-pr <number>` to wait for closure, then cleanup.
+
+### 5) Sync required GitHub labels
 
 ```bash
 .harmony/agency/_ops/scripts/sync-github-labels.sh
@@ -96,6 +113,7 @@ Behavior:
 3. Open draft PR with `git-pr-open.sh`.
 4. Mark ready + request merge with `git-pr-ship.sh`.
 5. Let required checks and branch rules enforce final merge safety.
+6. Let cleanup enforcement return local git state to `main` + aligned origin.
 
 ### High-impact guarded lane
 
@@ -104,6 +122,7 @@ When touching high-impact paths (for example `.github/` or governance paths):
 1. Add `accept:human` before merge.
 2. Keep PR focused and explicitly document risk/rollback.
 3. Use `git-pr-ship.sh --accept-human` to preserve metadata-level check-in.
+4. Cleanup watcher will run automatically once the PR is eventually closed.
 
 ---
 

--- a/.harmony/agency/practices/git-github-autonomy-workflow-v1.md
+++ b/.harmony/agency/practices/git-github-autonomy-workflow-v1.md
@@ -79,6 +79,7 @@ Primary autonomy workflows:
 - `.github/workflows/pr-triage.yml`
 - `.github/workflows/pr-autonomy-policy.yml`
 - `.github/workflows/pr-auto-merge.yml`
+- `.github/workflows/pr-clean-state-enforcer.yml`
 - `.github/workflows/pr-stale-close.yml`
 - `.github/workflows/release-please.yml`
 - `.github/workflows/autonomy-release-health.yml`
@@ -114,6 +115,7 @@ For local flow:
 - `.harmony/agency/_ops/scripts/git-wt-new.sh`
 - `.harmony/agency/_ops/scripts/git-pr-open.sh`
 - `.harmony/agency/_ops/scripts/git-pr-ship.sh`
+- `.harmony/agency/_ops/scripts/git-pr-cleanup.sh`
 - `.harmony/agency/_ops/scripts/sync-github-labels.sh`
 
 For GitHub operations and drift remediation commands, use:

--- a/.harmony/agency/practices/github-autonomy-runbook.md
+++ b/.harmony/agency/practices/github-autonomy-runbook.md
@@ -11,6 +11,7 @@ GitHub autonomy workflows:
 - `.github/workflows/pr-triage.yml`
 - `.github/workflows/pr-autonomy-policy.yml`
 - `.github/workflows/pr-auto-merge.yml`
+- `.github/workflows/pr-clean-state-enforcer.yml`
 - `.github/workflows/pr-stale-close.yml`
 - `.github/workflows/release-please.yml`
 - `.github/workflows/autonomy-release-health.yml`
@@ -97,6 +98,7 @@ Before expecting autonomous low-risk merges:
 3. Actions workflow setting has `can_approve_pull_request_reviews=true`.
 4. `AUTONOMY_PAT` is set as a repository Actions secret.
 5. (Optional) `AUTONOMY_AUTO_CLOSE_ENABLED=true` if stale draft auto-close is desired.
+6. (Optional) `AUTONOMY_ATTENTION_AFTER_HOURS=<n>` to tune attention indicator threshold.
 
 Useful verification commands:
 
@@ -104,6 +106,7 @@ Useful verification commands:
 gh secret list --app actions | rg '^AUTONOMY_PAT'
 gh variable list | rg '^AUTONOMY_AUTO_MERGE_ENABLED'
 gh variable list | rg '^AUTONOMY_AUTO_CLOSE_ENABLED'
+gh variable list | rg '^AUTONOMY_ATTENTION_AFTER_HOURS'
 gh api repos/<owner>/<repo>/actions/permissions/workflow
 gh api repos/<owner>/<repo>/rulesets
 ```
@@ -115,6 +118,29 @@ For Phase C release acceleration:
    `main`.
 3. `AUTONOMY_PAT` includes `Contents`, `Pull requests`, and `Issues` write
    permissions.
+
+---
+
+## Clean-State Enforcement
+
+`PR Clean State Enforcer` keeps PR/branch state converging to clean:
+
+- Workflow: `.github/workflows/pr-clean-state-enforcer.yml`
+- Triggers: PR events, schedule, and manual dispatch.
+- Default attention threshold: 4 hours since last PR update when blocked/manual.
+
+Remote cleanup behavior:
+
+- Deletes closed PR head refs on origin when no open PR still references the branch.
+- Labels blocked/manual PRs with `autonomy:attention-required`.
+- Opens/updates issue `[autonomy-health] open-pr attention required` when action is needed.
+- Auto-closes the attention issue when queue is healthy.
+
+Local cleanup expectation:
+
+- Use `.harmony/agency/_ops/scripts/git-pr-ship.sh` for shipping; it triggers
+  local cleanup after closure (or starts a watcher for manual lanes).
+- On demand, run `.harmony/agency/_ops/scripts/git-pr-cleanup.sh`.
 
 ---
 


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Adds clean-state enforcement across GitHub and local operator tooling so PR closure reliably converges both remote and local git state.

## Why

You requested a policy that always trends to a clean repo state, with prompt indicators for manual/blocking PRs and automatic cleanup once PRs close.
No-Issue: autonomy clean-state enforcement rollout.

## How

- Added `.github/workflows/pr-clean-state-enforcer.yml`:
  - labels open blocked/manual PRs with `autonomy:attention-required`
  - opens/updates `[autonomy-health] open-pr attention required`
  - auto-closes that issue when healthy
  - deletes closed head refs on origin when no open PR references them
- Added local `.harmony/agency/_ops/scripts/git-pr-cleanup.sh`:
  - enforces post-closure cleanup (local + origin branches)
  - aligns local `main` with `origin/main`
  - supports watch mode (`--watch-pr`) for delayed/manual merges
- Updated `git-pr-ship.sh`:
  - waits for closure (auto lane) and runs cleanup
  - launches background cleanup watcher when PR remains open or manual lane is used
- Updated `git-wt-new.sh` to run clean-state preflight by default.
- Updated autonomy docs/runbooks for new enforcement behavior.

## Tradeoffs

- `git-pr-ship.sh` may wait up to timeout before handing off to a background watcher.
- Clean-state enforcement is strongest when using the provided scripts (`git-pr-ship.sh`, `git-wt-new.sh`, `git-pr-cleanup.sh`).

## Testing

- `bash -n` validated updated/new scripts.
- `git diff --check` reports clean diff hygiene.
- YAML parse check succeeded for `pr-clean-state-enforcer.yml`.
- Dry-run of cleanup script succeeds in preflight mode (`--no-sync-main --dry-run`).

## Rollout

Merge to `main`; workflow and local script enforcement activate immediately.

## Risk Rubric

- Risk class: [ ] Trivial [ ] Low [x] Medium [ ] High
- Rollback plan: revert this PR commit
- Rollback handle: `git revert <merge-commit>`
- Flags changed (name, owner, expiry, rollout): optional `AUTONOMY_ATTENTION_AFTER_HOURS`
- Autonomy eligibility: [ ] autonomy:auto-merge [x] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: none

## Observability and Performance

- Traces/logs/metrics for changed flows: GitHub Actions logs and clean-state issue/label indicators
- Representative traces for high risk changes: n/a
- Performance or bundle impact: none

## License and Provenance

- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

Workflow and script changes only.
