### PR TITLE
fix(agency): fail closed on workflow permissions reads

### DIFF
--- a/.github/workflows/autonomy-release-health.yml
+++ b/.github/workflows/autonomy-release-health.yml
@@ -118,9 +118,7 @@ jobs:
             && workflow_permissions_payload="$(gh api "repos/${GH_REPO}/actions/permissions/workflow" 2>/dev/null)"; then
             pass "Fetched workflow permissions via API (workflow token fallback)."
           else
-            workflow_permissions_payload=""
-            echo "::warning::Unable to fetch workflow permissions (repos/${GH_REPO}/actions/permissions/workflow); skipping this invariant for this run."
-            pass "Workflow permissions endpoint inaccessible; skipped can_approve_pull_request_reviews invariant."
+            fail "Unable to fetch workflow permissions (repos/${GH_REPO}/actions/permissions/workflow)."
           fi
 
           if [[ -n "${repo_payload}" ]]; then


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Removes the skip fallback and restores fail-closed behavior for workflow
permissions reads in `autonomy-release-health`.

## Why

You requested strict enforcement now that the fine-grained PAT has
Administration read/write.

No-Issue: strict follow-up on control-plane health enforcement.

## How

On failed fetch of `actions/permissions/workflow`, the workflow now records a
hard failure instead of warning+skip.

## Tradeoffs

Health runs will fail if token access regresses, by design.

## Testing

- YAML parse: `.github/workflows/autonomy-release-health.yml`
- Local validation: `bash .harmony/agency/_ops/scripts/validate-agency.sh`

## Rollout

Merge and run `Autonomy Release Health` on `main`.

## Risk Rubric

- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High
- Rollback plan: revert this PR.
- Rollback handle: `git revert <merge-commit>`
- Flags changed (name, owner, expiry, rollout): none
- Autonomy eligibility: [ ] autonomy:auto-merge [x] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: n/a

## Observability and Performance

- Fewer false-green outcomes; strict token access enforcement.

## License and Provenance

- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

n/a
