### PR TITLE
chore(release): tune pre-1.0 version bump policy

### DIFF
--- a/.harmony/agency/practices/github-autonomy-runbook.md
+++ b/.harmony/agency/practices/github-autonomy-runbook.md
@@ -171,6 +171,10 @@ For Phase C release acceleration:
    `main`.
 3. `AUTONOMY_PAT` includes `Contents`, `Pull requests`, and `Issues` write
    permissions.
+4. Pre-1.0 cadence is pinned in `release-please-config.json` with
+   `"bump-minor-pre-major": false` and
+   `"bump-patch-for-minor-pre-major": true` so non-breaking `0.x` releases
+   advance by patch by default.
 
 ---
 
@@ -392,6 +396,9 @@ Phase 5 (provider-agnostic AI gate):
   `AUTONOMY_PAT` is missing `Pull requests: Read and write`.
 - `release-please` fails when applying labels/comments on release PR:
   `AUTONOMY_PAT` is missing `Issues: Read and write`.
+- Release tags are advancing too quickly while `<1.0.0`:
+  verify `release-please-config.json` keeps `"bump-minor-pre-major": false`
+  and `"bump-patch-for-minor-pre-major": true`.
 - `Autonomy Release Health` fails with
   `AUTONOMY_AUTO_MERGE_ENABLED=false`: set repository variable back to `true`
   unless intentionally paused for incident response.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "9ecda34181acbec66e9484a229e08b6e73f92988",
   "release-type": "simple",
+  "bump-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
   "packages": {
     ".": {


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Configure release-please to reduce pre-1.0 version churn and document the policy in the autonomy runbook.

## Why

Patch-level increments are preferable while Harmony is stabilizing before `1.0.0`.
No-Issue: release cadence calibration for ongoing autonomy rollout.

## How

Set `bump-minor-pre-major=false` and `bump-patch-for-minor-pre-major=true` in `release-please-config.json`, then add matching operator guidance and troubleshooting notes to `github-autonomy-runbook.md`.

## Tradeoffs

Pre-1.0 feature commits no longer auto-promote minor versions by default. If a minor bump is intentionally needed, that must be handled explicitly.

## Testing

Validated locally with:
- `jq . release-please-config.json`
- `git diff --check`

## Rollout

n/a

## Risk Rubric

- Risk class: [x] Trivial [ ] Low [ ] Medium [ ] High
- Rollback plan: revert this PR to restore prior release-please bump behavior.
- Rollback handle: revert commit `6e77258b`.
- Flags changed (name, owner, expiry, rollout): none.
- Autonomy eligibility: [x] autonomy:auto-merge [ ] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none.
- Threat model update/link: not required; no runtime surface changed.

## Observability and Performance

- Traces/logs/metrics for changed flows: n/a.
- Representative traces for high risk changes: n/a.
- Performance or bundle impact: none.

## License and Provenance

- New dependencies and licenses: none.
- Generated code/templates provenance notes: none.

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [ ] All review conversations resolved

## Screenshots / Notes

No UI changes.
