### PR TITLE
fix(workflows): fall back when rg is unavailable

### DIFF
--- a/.harmony/orchestration/runtime/workflows/_ops/scripts/audit-workflow-system.sh
+++ b/.harmony/orchestration/runtime/workflows/_ops/scripts/audit-workflow-system.sh
@@ -52,6 +52,11 @@ declare -A SCENARIO_RESULTS=()
 
 FINDINGS=()
 SCANNED_PATHS=()
+HAS_RG=0
+
+if command -v rg >/dev/null 2>&1; then
+  HAS_RG=1
+fi
 
 usage() {
   cat <<'USAGE'
@@ -137,10 +142,74 @@ frontmatter_query() {
   rm -f "$tmp_file"
 }
 
+matches_file_regex() {
+  local pattern="$1"
+  local file="$2"
+  if [[ "$HAS_RG" -eq 1 ]]; then
+    rg -q -- "$pattern" "$file"
+  else
+    grep -Eq -- "$pattern" "$file"
+  fi
+}
+
+matches_paths_regex() {
+  local pattern="$1"
+  shift
+  local path
+  if [[ "$HAS_RG" -eq 1 ]]; then
+    rg -q -- "$pattern" "$@"
+  else
+    for path in "$@"; do
+      if [[ -d "$path" ]]; then
+        grep -RqsE -- "$pattern" "$path" && return 0
+      elif [[ -f "$path" ]]; then
+        grep -Eq -- "$pattern" "$path" && return 0
+      fi
+    done
+    return 1
+  fi
+}
+
+matches_paths_fixed() {
+  local token="$1"
+  shift
+  local path
+  if [[ "$HAS_RG" -eq 1 ]]; then
+    rg -Fq -- "$token" "$@"
+  else
+    for path in "$@"; do
+      if [[ -d "$path" ]]; then
+        grep -RqsF -- "$token" "$path" && return 0
+      elif [[ -f "$path" ]]; then
+        grep -Fq -- "$token" "$path" && return 0
+      fi
+    done
+    return 1
+  fi
+}
+
+matches_stdin_regex() {
+  local pattern="$1"
+  if [[ "$HAS_RG" -eq 1 ]]; then
+    rg -q -- "$pattern"
+  else
+    grep -Eq -- "$pattern"
+  fi
+}
+
+extract_markdown_link_targets() {
+  local file="$1"
+  if [[ "$HAS_RG" -eq 1 ]]; then
+    rg -No '\[[^]]+\]\(([^)]+)\)' -r '$1' "$file" || true
+  else
+    grep -Eo '\[[^]]+\]\(([^)]+)\)' "$file" | sed -E 's/.*\(([^)]+)\)$/\1/' || true
+  fi
+}
+
 has_section() {
   local file="$1"
   local title="$2"
-  rg -q "^##[[:space:]]+${title}([[:space:]]|\$)" "$file"
+  matches_file_regex "^##[[:space:]]+${title}([[:space:]]|\$)" "$file"
 }
 
 has_any_section() {
@@ -170,7 +239,7 @@ link_score() {
     if [[ -e "$(cd "$(dirname "$file")" && cd "$target" 2>/dev/null && pwd)" ]] || [[ -e "$(dirname "$file")/$target" ]]; then
       valid=$((valid + 1))
     fi
-  done < <(rg -No '\[[^]]+\]\(([^)]+)\)' -r '$1' "$file" || true)
+  done < <(extract_markdown_link_targets "$file")
 
   if [[ "$total" -eq 0 ]]; then
     printf '1.0|0\n'
@@ -364,7 +433,7 @@ workflow_primary_doc() {
 
 workflow_has_external_markers() {
   local artifact="$1"
-  rg -q '\b(pnpm|npm|npx|uv|pip install|swift build|swift test|docker|alembic)\b' "$artifact"/*
+  matches_paths_regex '\b(pnpm|npm|npx|uv|pip install|swift build|swift test|docker|alembic)\b' "$artifact"
 }
 
 score_workflow() {
@@ -443,7 +512,7 @@ score_workflow() {
 
   while IFS= read -r parameter_name; do
     [[ -z "$parameter_name" ]] && continue
-    if ! rg -Fq "$parameter_name" "$workflow_file" "$primary_doc" "$artifact" 2>/dev/null; then
+    if ! matches_paths_fixed "$parameter_name" "$workflow_file" "$primary_doc" "$artifact" 2>/dev/null; then
       parameter_mentions=0
       add_finding "parameter-io-contract" "medium" "$artifact_rel" "registry parameter '$parameter_name' is undocumented in workflow content" "Document registry parameters in workflow usage or step guidance." "new-audit-only"
     fi
@@ -653,7 +722,7 @@ system_level_checks() {
   if [[ -s "$edge_file" ]]; then
     local tsort_output=""
     tsort_output="$(tsort "$edge_file" 2>&1 >/dev/null || true)"
-    if printf '%s' "$tsort_output" | rg -q 'cycle in data'; then
+    if printf '%s' "$tsort_output" | matches_stdin_regex 'cycle in data'; then
       add_finding "portfolio-coverage" "high" "$(rel_path "$REGISTRY")" "workflow dependency cycle detected" "Remove workflow dependency cycles from registry depends_on declarations." "new-audit-only"
     fi
   fi


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Makes the workflow-system audit portable to runners that do not have
`rg` installed by falling back to `grep` for the small set of search
operations the audit needs.

## Why

`Harness Self-Containment Validation` was failing in CI because
`audit-workflow-system.sh` assumed `rg` was present on the runner.
That turned a tooling assumption into a blocking validation failure and
prevented unrelated PRs from merging.

No-Issue: unblock workflow validation on grep-only runners

## How

Add the same `HAS_RG` detection pattern already used by
`validate-workflows.sh`, wrap the audit's regex and fixed-string search
sites in helper functions, and preserve the existing scoring behavior.

## Profile Selection Receipt

- Semantic version source(s): `version.txt` = `0.4.6`
- Release state (`pre-1.0` or `stable`): `pre-1.0`
- `change_profile` (`atomic` or `transitional`): `atomic`
- Hard-gate facts (downtime, coordination, migration/backfill, rollback, blast radius, compliance): no downtime; no external coordination; no migration or backfill; rollback is a single revert; blast radius is limited to workflow validation behavior; compliance need is portability on standard CI runners
- Tie-break status: no tie-break; no `transitional` hard gate applies
- `transitional_exception_note` (required when `pre-1.0` + `transitional`): n/a

## Implementation Plan

- Workstreams and scope: patch the workflow-system audit search helpers only
- Public interfaces/types/contracts affected: none
- Test scenarios: run `validate-workflows.sh` with `rg` hidden from `PATH`
- Assumptions/defaults: `grep` remains available on supported CI runners

## Impact Map (code, tests, docs, contracts)

- Code: `.harmony/orchestration/runtime/workflows/_ops/scripts/audit-workflow-system.sh`
- Tests: targeted validator execution only
- Docs: none
- Contracts: none

## Compliance Receipt

- [x] Selected exactly one execution profile before planning/implementation.
- [x] Applied release-maturity gate from semantic version.
- [x] Enforced pre-1.0 default (`atomic`) unless hard gates required `transitional`.
- [x] Included `transitional_exception_note` when required.
- [x] Included tie-break escalation when applicable.
- [x] Updated impacted contracts/docs/tests.
- [x] Honored charter change-control constraint (no direct principles charter edits without override evidence).

## Exceptions/Escalations

none

## Tradeoffs

The fallback uses `grep`/`sed` equivalents instead of forcing a ripgrep
installation in CI. That keeps the validator portable, at the cost of a
small amount of duplicated search-wrapper code inside the audit script.

## Testing

- `PATH="$tmpbin:/usr/bin:/bin:/usr/sbin:/sbin" ./.harmony/orchestration/runtime/workflows/_ops/scripts/validate-workflows.sh`
  with Homebrew `bash` and `yq` exposed in `tmpbin`, and no `rg`
- `git diff --check`

## Rollout

n/a

## Convivial Purpose Check

- [x] Feature expands genuine user capability (not synthetic engagement).
- [x] Attention and interruption behavior are justified and user-controllable.
- [x] No manipulative patterns or dark-pattern mechanics are introduced.
- [x] Data collection/extraction risk is minimal and explicitly justified.

## Risk Rubric

- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High
- Rollback plan: revert the squash commit if validation behavior regresses
- Rollback handle: GitHub revert on the merged PR or `git revert` on the squash commit
- Flags changed (name, owner, expiry, rollout): none
- Autonomy eligibility: [x] autonomy:auto-merge [ ] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: none required

## Observability and Performance

- Traces/logs/metrics for changed flows: n/a
- Representative traces for high risk changes: n/a
- Performance or bundle impact: negligible

## License and Provenance

- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [ ] Tests added or updated
- [ ] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

No visual changes.
