### PR TITLE
chore(repo): stop ignoring proposals workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ runs/
 
 # Additional local outputs and proposal workspaces
 out/
-.proposals/
 
 # Harmony runtime state (local/cache/traces)
 .harmony/engine/_ops/state/


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Stop ignoring `.proposals/` in the repository root `.gitignore`.

## Why

This restores visibility of proposal workspace content to git when it is
intentionally present.
No-Issue: repository hygiene update.

## How

Removed the `.proposals/` ignore entry from `.gitignore` and kept the change
isolated from the orchestration design-package work.

## Profile Selection Receipt

- Semantic version source(s): no stronger package-local semver authority;
  conservative repository posture used
- Release state (`pre-1.0` or `stable`): `pre-1.0`
- `change_profile` (`atomic` or `transitional`): `atomic`
- Hard-gate facts (downtime, coordination, migration/backfill, rollback, blast radius, compliance): no downtime; no coordination; no migration/backfill; rollback is git revert; blast radius limited to repository ignore behavior; no compliance impact
- Tie-break status: none
- `transitional_exception_note` (required when `pre-1.0` + `transitional`): n/a

## Implementation Plan

- Workstreams and scope:
  - remove the `.proposals/` ignore rule
- Public interfaces/types/contracts affected:
  - none
- Test scenarios:
  - verify the worktree is clean after commit and branch push
- Assumptions/defaults:
  - `.proposals/` should no longer be treated as a universally local-only path

## Impact Map (code, tests, docs, contracts)

- Code:
  - none
- Tests:
  - none
- Docs:
  - none
- Contracts:
  - none

## Compliance Receipt

- [x] Selected exactly one execution profile before planning/implementation.
- [x] Applied release-maturity gate from semantic version.
- [x] Enforced pre-1.0 default (`atomic`) unless hard gates required `transitional`.
- [x] Included `transitional_exception_note` when required.
- [x] Included tie-break escalation when applicable.
- [x] Updated impacted contracts/docs/tests.
- [x] Honored charter change-control constraint (no direct principles charter edits without override evidence).

## Exceptions/Escalations

none.

## Tradeoffs

This will cause `.proposals/` content to appear in git status when present,
which is the intended outcome of removing the ignore rule.

## Testing

- `git status -sb`

## Rollout

n/a.

## Convivial Purpose Check

- [x] Feature expands genuine user capability (not synthetic engagement).
- [x] Attention and interruption behavior are justified and user-controllable.
- [x] No manipulative patterns or dark-pattern mechanics are introduced.
- [x] Data collection/extraction risk is minimal and explicitly justified.

## Risk Rubric

- Risk class: [x] Trivial [ ] Low [ ] Medium [ ] High
- Rollback plan:
  - revert the ignore-rule removal
- Rollback handle:
  - git revert the commit
- Flags changed (name, owner, expiry, rollout):
  - none
- Autonomy eligibility: [x] autonomy:auto-merge [ ] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes:
  - none
- Threat model update/link:
  - none

## Observability and Performance

- Traces/logs/metrics for changed flows:
  - none
- Representative traces for high risk changes:
  - n/a
- Performance or bundle impact:
  - n/a

## License and Provenance

- New dependencies and licenses:
  - none
- Generated code/templates provenance notes:
  - none

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

Notes:
- this PR contains only the `.gitignore` change.
