### PR TITLE
docs(design-packages): add orchestration model eval prompt

### DIFF
--- a/.design-packages/prompts/orchestration-domain-all-surfaces-architectural-model-eval.md
+++ b/.design-packages/prompts/orchestration-domain-all-surfaces-architectural-model-eval.md
@@ -1,0 +1,363 @@
+# Orchestration Domain All-Surfaces Architectural Model Evaluation
+
+You are an architectural design expert agent operating inside the Harmony repository.
+
+Your task is to design and evaluate the architectural model for the full orchestration surface portfolio inside the package:
+
+- `.design-packages/orchestration-domain-design-package/`
+
+This is a package-first design task, not a live Harmony implementation task.
+
+Your job is to determine the best-fit architectural model for all orchestration domain surfaces defined by the package, then produce the concrete proposal-package file updates required to make that full surface set implementation-ready before any promotion into live `.harmony/` surfaces.
+
+Primary objective
+
+For the orchestration surface portfolio, produce:
+
+1. a cross-surface architectural evaluation covering every orchestration surface in scope
+2. a best-fit package-local target design for each surface and the cross-surface boundaries between them
+3. the updated design proposal package files needed to encode that design coherently across the package
+
+Do not stop at critique or recommendation.
+Carry the work through to package-level design outputs that another implementation agent could apply directly.
+
+Target surfaces
+
+Evaluate all orchestration domain surfaces defined by the package:
+
+- `workflows`
+- `missions`
+- `automations`
+- `watchers`
+- `queue`
+- `runs`
+- `incidents`
+- `campaigns`
+
+Scope and authority
+
+- Evaluate the full orchestration surface portfolio, not a single isolated surface.
+- Work inside the orchestration design package first.
+- Treat package-local normative docs as the primary design authority for target orchestration behavior.
+- Treat current live `.harmony/orchestration/` surfaces as integration and promotion context, not as the primary target authority.
+- Inspect adjacent package files when they directly govern, validate, describe, or promote one or more orchestration surfaces or their shared contracts.
+- Keep the work package-first and implementation-ready.
+- Do not redesign the entire orchestration domain beyond what is required to make the surface portfolio coherent, authoritative, and promotion-ready.
+
+Package-local authority model
+
+Within the orchestration design package, use this source-of-truth posture:
+
+1. specific contract docs in `contracts/`
+2. detailed control docs
+3. core domain and architecture normative docs
+4. implementation-readiness and canonicalization planning docs
+5. `surfaces/` docs
+6. reference and historical docs
+7. ADRs and examples
+
+Package-first design rule
+
+The design package is the implementation-ready proposal surface.
+Your output must strengthen that package directly.
+
+That means:
+
+- define the correct target architecture for every orchestration surface inside the design package
+- define the correct cross-surface authority splits, linkage rules, and validation expectations where the surfaces interact
+- update package docs, contracts, schemas, fixtures, readiness gates, and promotion targets only where the portfolio change truly requires it
+- avoid drifting into live `.harmony` implementation details except where promotion targets must be clarified in `canonicalization-target-map.md`
+
+Core architectural principle
+
+For the orchestration surface portfolio, determine the smallest robust contract-first design that fits each surface's actual role in orchestration while keeping the full portfolio coherent as one domain.
+
+The answer must be justified by the surfaces themselves:
+
+- what each surface is responsible for
+- who or what consumes each surface
+- what must be machine-readable
+- what must remain explicit contract data
+- what may remain prose
+- how discovery, routing, definition, state, and evidence should be separated for each surface
+- where cross-surface contracts are required and where they would be unnecessary complexity
+
+Do not force every surface to mimic every other orchestration surface unless the shared pattern is structurally warranted.
+
+Universal rules to enforce
+
+1. Every target surface must have a clear authority model.
+2. If a surface drives execution, routing, discovery, validation, or stateful orchestration behavior, the authoritative behavior must be grounded in structured machine-readable artifacts.
+3. Markdown may exist, but its role must be explicit:
+   - surface purpose and non-goals
+   - executor-facing instructions subordinate to contracts
+   - explanatory or operational guidance
+   - subordinate evidence or operator narrative where the surface model allows it
+4. Human-readable Markdown must not be the canonical execution contract for an execution-bearing orchestration surface.
+5. Discovery, metadata, definition, mutable state, and durable evidence must not collapse into one ambiguous authority layer.
+6. Validators must target the real authority artifacts first, then supporting drift checks.
+7. If a surface requires schema-backed artifacts, the package must include schemas and valid/invalid fixtures.
+8. Package outputs must remain implementation-ready and promotion-aware.
+9. Cross-surface consistency should come from explicit contracts and shared rules, not from superficial filename uniformity.
+
+Surface-local choices that may vary
+
+Do not normalize these unless the surface itself needs it:
+
+- number of contract files
+- whether the surface follows collection-surface, response-object, coordination-object, or infrastructure-surface layering
+- filenames such as `manifest.yml`, `registry.yml`, `index.yml`, `schema.yml`, `trigger.yml`, `bindings.yml`, or other shapes
+- whether the definition layer is one file or several
+- whether Markdown instruction assets are needed at all
+- whether a new package-local contract, schema, or fixture is required
+- whether live Harmony promotion should add runtime, governance, practices, validation, or only addenda to existing surfaces
+
+Important anti-patterns
+
+- Do not cargo-cult workflow conventions into unrelated orchestration surfaces.
+- Do not assume every surface needs staged Markdown assets.
+- Do not assume every runtime surface needs the same discovery stack.
+- Do not treat the current live Harmony shape as the answer if the package evidence says otherwise.
+- Do not preserve package inconsistency just because it already exists.
+- Do not invent cross-surface complexity unless the surface portfolio actually needs it.
+- Do not recommend package file changes without naming the exact paths and content changes required.
+
+Required package context to use
+
+At minimum, inspect and use the parts of the design package that govern the portfolio as a whole:
+
+- `README.md`
+- `normative-dependencies-and-source-of-truth-map.md`
+- `contracts/README.md`
+- `contracts/discovery-and-authority-layer-contract.md`
+- `surface-artifact-schemas.md`
+- `implementation-readiness.md`
+- `assurance-and-acceptance-matrix.md`
+- `canonicalization-target-map.md`
+- `domain-model.md`
+- `runtime-architecture.md`
+- `orchestration-execution-model.md`
+- `orchestration-lifecycle.md`
+- `failure-model.md`
+- `observability.md`
+- `dependency-resolution.md`
+- `concurrency-control-model.md`
+- `routing-authority-and-execution-control.md`
+- `evidence-observability-and-retention-spec.md`
+
+Also inspect all target surface docs:
+
+- `surfaces/workflows.md`
+- `surfaces/missions.md`
+- `surfaces/automations.md`
+- `surfaces/watchers.md`
+- `surfaces/queue.md`
+- `surfaces/runs.md`
+- `surfaces/incidents.md`
+- `surfaces/campaigns.md`
+
+Also inspect the relevant supporting contracts and proof artifacts for the portfolio:
+
+- `contracts/versioning-and-compatibility-policy.md`
+- `contracts/cross-surface-reference-contract.md`
+- `contracts/decision-record-contract.md`
+- `contracts/workflow-execution-contract.md`
+- `contracts/mission-object-contract.md`
+- `contracts/mission-workflow-binding-contract.md`
+- `contracts/automation-execution-contract.md`
+- `contracts/watcher-definition-contract.md`
+- `contracts/watcher-event-contract.md`
+- `contracts/queue-item-and-lease-contract.md`
+- `contracts/run-linkage-contract.md`
+- `contracts/incident-object-contract.md`
+- `contracts/campaign-object-contract.md`
+- `contracts/campaign-mission-coordination-contract.md`
+- relevant files under `contracts/schemas/`
+- relevant files under `contracts/fixtures/valid/`
+- relevant files under `contracts/fixtures/invalid/`
+
+Portfolio evaluation questions
+
+1. What is each target surface responsible for inside orchestration?
+2. Which orchestration actors consume each surface?
+3. What parts of each surface's behavior must be machine-readable to prevent drift or unsafe execution?
+4. What parts, if any, are better expressed as prose or operator guidance?
+5. Which authority layers should exist for each surface?
+   - discovery
+   - routing/metadata
+   - definition
+   - state
+   - evidence
+6. Does the current package define those layers clearly enough for each surface?
+7. Do the current cross-surface contracts define the portfolio boundaries clearly enough?
+8. Which surfaces need new or revised package-local contracts?
+9. Which surfaces need new or revised schema-backed artifacts?
+10. Which package docs become stale or incomplete if the portfolio model changes?
+11. What is the smallest coherent package change set that makes the full orchestration surface portfolio implementation-ready?
+
+How to reason about live Harmony surfaces
+
+- Use live `.harmony/orchestration/` artifacts only as current-state integration context.
+- Do not let the current implementation freeze the design package into an inferior model.
+- When promotion implications exist, record them in package-local promotion planning rather than redesigning live runtime files.
+
+Design-package update rules
+
+Your output must identify the minimum necessary set of package files to update.
+
+When the orchestration surface portfolio architecture changes, consider whether each of these package files must also change:
+
+- `README.md`
+- `normative-dependencies-and-source-of-truth-map.md`
+- `surface-artifact-schemas.md`
+- `implementation-readiness.md`
+- `assurance-and-acceptance-matrix.md`
+- `canonicalization-target-map.md`
+- `artifact-catalog.md`
+- `surfaces/workflows.md`
+- `surfaces/missions.md`
+- `surfaces/automations.md`
+- `surfaces/watchers.md`
+- `surfaces/queue.md`
+- `surfaces/runs.md`
+- `surfaces/incidents.md`
+- `surfaces/campaigns.md`
+- `contracts/discovery-and-authority-layer-contract.md`
+- `contracts/cross-surface-reference-contract.md`
+- any target-specific contract doc affected by the evaluation
+- any target-specific schema under `contracts/schemas/`
+- any target-specific valid or invalid fixture under `contracts/fixtures/`
+
+Only update a file when the surface-portfolio design actually requires it.
+Do not touch unrelated package files for cosmetic consistency.
+
+When to add contracts or schemas
+
+- Add or revise a contract doc when one or more surfaces need explicit machine-readable semantics, lifecycle guarantees, interface rules, linkage rules, or authority separation that are not already captured precisely enough.
+- Add or revise a schema when a required runtime artifact must validate deterministically.
+- Add valid and invalid fixtures whenever a schema-backed artifact is added or materially changed.
+- Update readiness and assurance docs whenever the acceptance surface or validator obligations change.
+- Update the canonicalization map whenever an evaluated surface's eventual live promotion shape changes.
+
+Special case: current shape is already correct
+
+If the orchestration surface portfolio is already architecturally correct in the package:
+
+- say so explicitly
+- keep the recommended changes minimal
+- still emit the package file updates that improve clarity, hardening, or validation if they are genuinely warranted
+- do not fabricate churn just to produce edits
+
+What to do
+
+1. Identify the target orchestration surface portfolio and its package-local authorities.
+2. Classify the current architecture of each surface:
+   - contract-first
+   - mixed
+   - markdown-first
+   - human-led/non-executable
+3. Determine the correct target model for each surface inside the design package.
+4. Determine the correct cross-surface authority model for the portfolio.
+5. Identify gaps in authority, discovery, layering, validation, schemas, fixtures, readiness, or promotion mapping.
+6. Decide whether the right solution is:
+   - preserve as-is
+   - tighten existing package docs
+   - add or revise contracts
+   - add or revise schemas and fixtures
+   - adjust readiness, assurance, or canonicalization docs
+7. Produce the minimum coherent package change set.
+8. Emit the updated design proposal package files.
+
+Required outputs
+
+Produce a complete result with these sections:
+
+1. Profile Selection Receipt
+   - `change_profile`
+   - `release_state`
+   - hard-gate facts
+   - rationale
+
+2. Executive Summary
+   - overall assessment of the orchestration surface portfolio in the design package
+   - strongest qualities
+   - most serious gaps
+
+3. Surface Portfolio Definition
+   - exact surface set under review
+   - responsibilities of each surface
+   - consumers of each surface
+   - operational significance of the portfolio as a whole
+
+4. Current Package Authority Model
+   - current canonical package artifacts
+   - current layer model by surface
+   - whether each surface is contract-first, mixed, markdown-first, or human-led/non-executable
+
+5. Surface-By-Surface Needs Analysis
+   - what must be machine-readable for each surface
+   - what may remain prose
+   - required authority layers by surface
+   - validator and proof obligations by surface
+   - cross-surface contracts that matter
+
+6. Findings
+   - prioritized findings with severity
+   - exact package paths
+   - why each issue matters for this surface portfolio specifically
+
+7. Recommended Package-Local Architecture
+   - best-fit target shape for the surface portfolio inside the design package
+   - canonical contract structure
+   - discovery/routing/definition/state/evidence split by surface
+   - schema and fixture model
+   - cross-surface contract expectations
+   - justification for why this design fits the portfolio
+
+8. Design Package Impact Map
+   - package docs to update
+   - contracts to update
+   - schemas and fixtures to update
+   - readiness, assurance, and promotion docs to update
+   - files that should remain unchanged
+
+9. Updated Design Proposal Package Files
+   - include every file that should change
+   - for each changed file provide:
+     - exact path
+     - change type: `create` or `update`
+     - concise reason
+     - complete revised file content when the file is new or tightly scoped
+     - exact replacement section content when only specific sections of a large existing file should change
+   - keep the file set minimal but sufficient for an implementation-ready design package
+
+10. Implementation Plan
+   - atomic vs transitional recommendation for landing the proposal-package changes
+   - rationale based on repo and portfolio facts
+   - ordered workstreams
+   - validation follow-up required before implementation in live `.harmony`
+
+11. Canonicalization Notes
+   - future live Harmony promotion implications by surface
+   - what belongs later in `.harmony/orchestration/`
+   - what should remain package-local until implementation proves out
+
+12. Acceptance Criteria
+   - concrete conditions proving the package is ready for implementation across the full orchestration surface portfolio
+
+13. Keep-As-Is Decisions
+   - what should remain unchanged
+   - what should remain surface-specific
+
+14. Non-Goals
+   - what should not be normalized
+   - what would be over-engineering for this portfolio
+
+Quality bar
+
+Be opinionated, concrete, and package-first.
+Ground every recommendation in the actual orchestration design package structure.
+Do not give generic framework advice.
+Do not stop at architectural commentary.
+Produce proposal artifacts that are precise enough for direct package update work.
+Prefer the smallest robust change set that makes the orchestration surface portfolio implementation-ready.


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Adds the remaining design-package prompt for a package-first architectural
model evaluation of the full orchestration surface portfolio.

## Why

This closes out the last local change so the orchestration design package has
a dedicated prompt for all-surface architecture evaluation work.

No-Issue: closing out the remaining local prompt change.

## How

Adds a single prompt document under `.design-packages/prompts/` that defines
scope, authority, required inputs, evaluation criteria, outputs, and package
update rules for orchestration portfolio review work.

## Profile Selection Receipt

- Semantic version source(s): latest repo tag `harmony-v0.4.7`
- Release state (`pre-1.0` or `stable`): `pre-1.0`
- `change_profile` (`atomic` or `transitional`): `atomic`
- Hard-gate facts (downtime, coordination, migration/backfill, rollback, blast radius, compliance): no downtime constraint, no external consumer coordination, no migration or backfill, rollback is a single commit revert, blast radius is one docs-only file, no compliance impact
- Tie-break status: no tie; `atomic` selected because no transitional hard gate applies
- `transitional_exception_note` (required when `pre-1.0` + `transitional`): n/a

## Implementation Plan

- Workstreams and scope: add the single orchestration evaluation prompt file and no other artifacts
- Public interfaces/types/contracts affected: none
- Test scenarios: manual review of prompt scope, authority language, and output contract
- Assumptions/defaults: this is a docs-only package artifact and does not change live `.harmony` behavior

## Impact Map (code, tests, docs, contracts)

- Docs: add `.design-packages/prompts/orchestration-domain-all-surfaces-architectural-model-eval.md`
- Tests: none
- Contracts: none
- Runtime code: none

## Compliance Receipt

- [x] Selected exactly one execution profile before planning/implementation.
- [x] Applied release-maturity gate from semantic version.
- [x] Enforced pre-1.0 default (`atomic`) unless hard gates required `transitional`.
- [x] Included `transitional_exception_note` when required.
- [x] Included tie-break escalation when applicable.
- [x] Updated impacted contracts/docs/tests.
- [x] Honored charter change-control constraint (no direct principles charter edits without override evidence).

## Exceptions/Escalations

none

## Tradeoffs

No automated validation was necessary for this docs-only prompt addition.
Review is limited to content correctness and scope clarity.

## Testing

Manual self-review of the staged Markdown content and final committed diff.

## Rollout

n/a

## Convivial Purpose Check

- [x] Feature expands genuine user capability (not synthetic engagement).
- [x] Attention and interruption behavior are justified and user-controllable.
- [x] No manipulative patterns or dark-pattern mechanics are introduced.
- [x] Data collection/extraction risk is minimal and explicitly justified.

## Risk Rubric

- Risk class: [x] Trivial [ ] Low [ ] Medium [ ] High
- Rollback plan: revert the single docs commit
- Rollback handle: `git revert 979a56a8`
- Flags changed (name, owner, expiry, rollout): none
- Autonomy eligibility: [x] autonomy:auto-merge [ ] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: none

## Observability and Performance

- Traces/logs/metrics for changed flows: none
- Representative traces for high risk changes: n/a
- Performance or bundle impact: none

## License and Provenance

- New dependencies and licenses: none
- Generated code/templates provenance notes: authored in-repo prompt content only

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [ ] Tests added or updated
- [ ] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

n/a
