### PR TITLE
feat(orchestration): add operator hardening surfaces

### DIFF
--- a/.github/workflows/harness-self-containment.yml
+++ b/.github/workflows/harness-self-containment.yml
@@ -63,6 +63,11 @@ jobs:
           chmod +x .harmony/assurance/runtime/_ops/scripts/validate-audit-convergence-contract.sh
           .harmony/assurance/runtime/_ops/scripts/validate-audit-convergence-contract.sh
 
+      - name: Test bounded-audit convergence validator
+        run: |
+          chmod +x .harmony/assurance/runtime/_ops/tests/test-validate-audit-convergence-contract.sh
+          .harmony/assurance/runtime/_ops/tests/test-validate-audit-convergence-contract.sh
+
       - name: Validate workflow manifest and dependency profiles
         run: |
           chmod +x .harmony/orchestration/runtime/workflows/_ops/scripts/validate-workflows.sh

--- a/.harmony/START.md
+++ b/.harmony/START.md
@@ -192,8 +192,8 @@ From repo root:
 .harmony/engine/runtime/run studio
 ```
 
-Use `studio` when you want a visual workflow graph + inspector + safe staged
-edit/apply flow.
+Use `studio` when you want a visual workflow graph, a read-only orchestration
+operations workspace, and the safe staged edit/apply flow.
 
 ## Assistants
 

--- a/.harmony/assurance/runtime/_ops/scripts/validate-audit-convergence-contract.sh
+++ b/.harmony/assurance/runtime/_ops/scripts/validate-audit-convergence-contract.sh
@@ -337,6 +337,51 @@ validate_bundle_metadata() {
   fi
 }
 
+bundle_dir_has_materialized_contract_files() {
+  local bundle_dir="$1"
+  local contract_file
+  local contract_files
+  contract_files=(bundle.yml findings.yml coverage.yml convergence.yml evidence.md commands.md validation.md inventory.md)
+
+  for contract_file in "${contract_files[@]}"; do
+    if [[ -f "$bundle_dir/$contract_file" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+bundle_dir_has_tracked_files() {
+  local bundle_dir="$1"
+  local bundle_rel="$1"
+
+  bundle_rel="${bundle_dir#$ROOT_DIR/}"
+  if ! git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 1
+  fi
+
+  if [[ -n "$(git -C "$ROOT_DIR" ls-files -- "$bundle_rel")" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+bundle_dir_is_authoritative() {
+  local bundle_dir="$1"
+
+  if bundle_dir_has_tracked_files "$bundle_dir"; then
+    return 0
+  fi
+
+  if bundle_dir_has_materialized_contract_files "$bundle_dir"; then
+    return 0
+  fi
+
+  return 1
+}
+
 validate_report_bundles() {
   require_dir "$REPORTS_DIR"
   require_file "$REPORTS_DIR/README.md"
@@ -349,15 +394,30 @@ validate_report_bundles() {
     pass "no flat bounded-audit markdown files in output/reports/audits/"
   fi
 
-  local bundle_dirs
-  mapfile -t bundle_dirs < <(find "$REPORTS_DIR" -mindepth 1 -maxdepth 1 -type d -name '20*-*' | sort)
+  local discovered_bundle_dirs
+  mapfile -t discovered_bundle_dirs < <(find "$REPORTS_DIR" -mindepth 1 -maxdepth 1 -type d -name '20*-*' | sort)
 
-  if [[ ${#bundle_dirs[@]} -eq 0 ]]; then
+  if [[ ${#discovered_bundle_dirs[@]} -eq 0 ]]; then
     pass "no bounded-audit bundles found yet (allowed)"
     return
   fi
 
-  pass "found ${#bundle_dirs[@]} bounded-audit bundle directories"
+  local bundle_dirs=()
+  local discovered_bundle
+  for discovered_bundle in "${discovered_bundle_dirs[@]}"; do
+    if bundle_dir_is_authoritative "$discovered_bundle"; then
+      bundle_dirs+=("$discovered_bundle")
+    else
+      pass "skipping non-authoritative audit workspace directory: ${discovered_bundle#$ROOT_DIR/}"
+    fi
+  done
+
+  if [[ ${#bundle_dirs[@]} -eq 0 ]]; then
+    pass "no authoritative bounded-audit bundles found yet (allowed)"
+    return
+  fi
+
+  pass "found ${#bundle_dirs[@]} authoritative bounded-audit bundle directories"
 
   local required_files
   required_files=(bundle.yml findings.yml coverage.yml convergence.yml evidence.md commands.md validation.md inventory.md)

--- a/.harmony/assurance/runtime/_ops/scripts/validate-harness-structure.sh
+++ b/.harmony/assurance/runtime/_ops/scripts/validate-harness-structure.sh
@@ -624,6 +624,7 @@ check_discovery_contracts() {
   require_file "$HARMONY_DIR/assurance/practices/complete.md"
   require_file "$HARMONY_DIR/assurance/practices/session-exit.md"
   require_file "$HARMONY_DIR/output/reports/audits/README.md"
+  require_file "$HARMONY_DIR/output/reports/workflows/README.md"
 
   require_file "$HARMONY_DIR/AGENTS.md"
   require_file "$HARMONY_DIR/OBJECTIVE.md"
@@ -1025,12 +1026,58 @@ check_output_migration_evidence_surface() {
   done
 }
 
+output_audit_bundle_has_materialized_contract_files() {
+  local bundle_dir="$1"
+  local contract_file
+  local contract_files
+  contract_files=(bundle.yml findings.yml coverage.yml convergence.yml evidence.md commands.md validation.md inventory.md)
+
+  for contract_file in "${contract_files[@]}"; do
+    if [[ -f "$bundle_dir/$contract_file" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+output_audit_bundle_has_tracked_files() {
+  local bundle_dir="$1"
+  local bundle_rel="$1"
+
+  bundle_rel="${bundle_dir#$ROOT_DIR/}"
+  if ! git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 1
+  fi
+
+  if [[ -n "$(git -C "$ROOT_DIR" ls-files -- "$bundle_rel")" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+output_audit_bundle_is_authoritative() {
+  local bundle_dir="$1"
+
+  if output_audit_bundle_has_tracked_files "$bundle_dir"; then
+    return 0
+  fi
+
+  if output_audit_bundle_has_materialized_contract_files "$bundle_dir"; then
+    return 0
+  fi
+
+  return 1
+}
+
 check_output_audit_evidence_surface() {
   local audits_reports_dir="$HARMONY_DIR/output/reports/audits"
   local flat_audit_evidence
-  local bundle_dirs
+  local discovered_bundle_dirs
+  local bundle_dirs=()
   local required_files
-  local bundle required rel bundle_name
+  local discovered_bundle bundle required rel bundle_name
 
   required_files=(bundle.yml findings.yml coverage.yml convergence.yml evidence.md commands.md validation.md inventory.md)
 
@@ -1047,14 +1094,28 @@ check_output_audit_evidence_surface() {
     pass "no flat bounded-audit evidence files under output/reports/audits/"
   fi
 
-  mapfile -t bundle_dirs < <(
+  mapfile -t discovered_bundle_dirs < <(
     find "$audits_reports_dir" -mindepth 1 -maxdepth 1 -type d -name '20*-*' | sort
   )
-  if [[ ${#bundle_dirs[@]} -eq 0 ]]; then
+  if [[ ${#discovered_bundle_dirs[@]} -eq 0 ]]; then
     pass "no bounded-audit evidence bundles present (optional surface)"
     return
   fi
-  pass "found ${#bundle_dirs[@]} bounded-audit evidence bundle directories"
+
+  for discovered_bundle in "${discovered_bundle_dirs[@]}"; do
+    if output_audit_bundle_is_authoritative "$discovered_bundle"; then
+      bundle_dirs+=("$discovered_bundle")
+    else
+      pass "skipping non-authoritative audit workspace directory: ${discovered_bundle#$ROOT_DIR/}"
+    fi
+  done
+
+  if [[ ${#bundle_dirs[@]} -eq 0 ]]; then
+    pass "no authoritative bounded-audit evidence bundles present (optional surface)"
+    return
+  fi
+
+  pass "found ${#bundle_dirs[@]} authoritative bounded-audit evidence bundle directories"
 
   for bundle in "${bundle_dirs[@]}"; do
     rel="${bundle#$ROOT_DIR/}"
@@ -1121,6 +1182,176 @@ check_output_audit_evidence_surface() {
         pass "bounded-audit bundle metadata inventory pointer valid: $rel/bundle.yml"
       else
         fail "bounded-audit bundle metadata inventory pointer must be inventory.md: $rel/bundle.yml"
+      fi
+    fi
+  done
+}
+
+output_workflow_bundle_has_materialized_contract_files() {
+  local bundle_dir="$1"
+  local contract_path
+  local contract_paths
+  contract_paths=(bundle.yml summary.md commands.md validation.md inventory.md)
+
+  for contract_path in "${contract_paths[@]}"; do
+    if [[ -f "$bundle_dir/$contract_path" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+output_workflow_bundle_has_tracked_files() {
+  local bundle_dir="$1"
+  local bundle_rel="$1"
+
+  bundle_rel="${bundle_dir#$ROOT_DIR/}"
+  if ! git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 1
+  fi
+
+  if [[ -n "$(git -C "$ROOT_DIR" ls-files -- "$bundle_rel")" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+output_workflow_bundle_is_authoritative() {
+  local bundle_dir="$1"
+
+  if output_workflow_bundle_has_tracked_files "$bundle_dir"; then
+    return 0
+  fi
+
+  if output_workflow_bundle_has_materialized_contract_files "$bundle_dir"; then
+    return 0
+  fi
+
+  return 1
+}
+
+check_output_workflow_bundle_surface() {
+  local workflows_reports_dir="$HARMONY_DIR/output/reports/workflows"
+  local flat_workflow_evidence
+  local discovered_bundle_dirs
+  local bundle_dirs=()
+  local required_files required_dirs
+  local discovered_bundle bundle required rel bundle_name
+
+  required_files=(bundle.yml summary.md commands.md validation.md inventory.md)
+  required_dirs=(reports stage-inputs stage-logs)
+
+  require_dir "$workflows_reports_dir"
+  require_file "$workflows_reports_dir/README.md"
+
+  mapfile -t flat_workflow_evidence < <(
+    find "$workflows_reports_dir" -mindepth 1 -maxdepth 1 -type f | sort |
+      grep -E '/[0-9]{4}-[0-9]{2}-[0-9]{2}-.*\.md$' || true
+  )
+  if [[ ${#flat_workflow_evidence[@]} -gt 0 ]]; then
+    fail "flat workflow evidence files are forbidden; use bundle directories under output/reports/workflows/"
+  else
+    pass "no flat workflow evidence files under output/reports/workflows/"
+  fi
+
+  mapfile -t discovered_bundle_dirs < <(
+    find "$workflows_reports_dir" -mindepth 1 -maxdepth 1 -type d -name '20*-*' | sort
+  )
+  if [[ ${#discovered_bundle_dirs[@]} -eq 0 ]]; then
+    pass "no workflow execution bundles present (optional surface)"
+    return
+  fi
+
+  for discovered_bundle in "${discovered_bundle_dirs[@]}"; do
+    if output_workflow_bundle_is_authoritative "$discovered_bundle"; then
+      bundle_dirs+=("$discovered_bundle")
+    else
+      pass "skipping non-authoritative workflow workspace directory: ${discovered_bundle#$ROOT_DIR/}"
+    fi
+  done
+
+  if [[ ${#bundle_dirs[@]} -eq 0 ]]; then
+    pass "no authoritative workflow execution bundles present (optional surface)"
+    return
+  fi
+
+  pass "found ${#bundle_dirs[@]} authoritative workflow execution bundle directories"
+
+  for bundle in "${bundle_dirs[@]}"; do
+    rel="${bundle#$ROOT_DIR/}"
+    bundle_name="$(basename "$bundle")"
+
+    for required in "${required_files[@]}"; do
+      if [[ ! -f "$bundle/$required" ]]; then
+        fail "workflow execution bundle missing required file (${required}): $rel"
+      else
+        pass "workflow execution bundle file present (${required}): $rel"
+      fi
+    done
+
+    for required in "${required_dirs[@]}"; do
+      if [[ ! -d "$bundle/$required" ]]; then
+        fail "workflow execution bundle missing required directory (${required}): $rel"
+      else
+        pass "workflow execution bundle directory present (${required}): $rel"
+      fi
+    done
+
+    if [[ -f "$bundle/bundle.yml" ]]; then
+      if grep -Eq '^kind:[[:space:]]*"?workflow-execution-bundle"?$' "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata kind valid: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata missing/invalid kind (workflow-execution-bundle): $rel/bundle.yml"
+      fi
+
+      if grep -Eq "^id:[[:space:]]*\"?${bundle_name}\"?$" "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata id matches directory: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata id must match directory name (${bundle_name}): $rel/bundle.yml"
+      fi
+
+      if grep -Eq '^summary:[[:space:]]*"?summary\.md"?$' "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata summary pointer valid: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata summary pointer must be summary.md: $rel/bundle.yml"
+      fi
+
+      if grep -Eq '^commands:[[:space:]]*"?commands\.md"?$' "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata commands pointer valid: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata commands pointer must be commands.md: $rel/bundle.yml"
+      fi
+
+      if grep -Eq '^validation:[[:space:]]*"?validation\.md"?$' "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata validation pointer valid: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata validation pointer must be validation.md: $rel/bundle.yml"
+      fi
+
+      if grep -Eq '^inventory:[[:space:]]*"?inventory\.md"?$' "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata inventory pointer valid: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata inventory pointer must be inventory.md: $rel/bundle.yml"
+      fi
+
+      if grep -Eq '^reports_dir:[[:space:]]*"?reports"?$' "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata reports_dir valid: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata reports_dir must be reports: $rel/bundle.yml"
+      fi
+
+      if grep -Eq '^stage_inputs_dir:[[:space:]]*"?stage-inputs"?$' "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata stage_inputs_dir valid: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata stage_inputs_dir must be stage-inputs: $rel/bundle.yml"
+      fi
+
+      if grep -Eq '^stage_logs_dir:[[:space:]]*"?stage-logs"?$' "$bundle/bundle.yml"; then
+        pass "workflow bundle metadata stage_logs_dir valid: $rel/bundle.yml"
+      else
+        fail "workflow bundle metadata stage_logs_dir must be stage-logs: $rel/bundle.yml"
       fi
     fi
   done
@@ -2048,6 +2279,7 @@ main() {
   check_output_decision_evidence_surface
   check_output_migration_evidence_surface
   check_output_audit_evidence_surface
+  check_output_workflow_bundle_surface
   check_domain_profile_shapes
   check_deprecated_agency_paths
   check_deprecated_engine_paths

--- a/.harmony/assurance/runtime/_ops/tests/test-design-package-workflow-runner.sh
+++ b/.harmony/assurance/runtime/_ops/tests/test-design-package-workflow-runner.sh
@@ -96,6 +96,8 @@ case_mock_runner_passes() {
   CLEANUP_PATHS+=("$bundle_root" "$summary_report")
 
   [[ "$final_verdict" == "mock-executed" ]] || return 1
+  [[ "$bundle_root" == *"/.harmony/output/reports/workflows/"* ]] || return 1
+  [[ "$bundle_root" != *"/.harmony/output/reports/audits/"* ]] || return 1
   assert_dir_exists "$bundle_root" || return 1
   assert_file_exists "$summary_report" || return 1
   assert_file_exists "$bundle_root/reports/01-design-package-audit.md" || return 1
@@ -128,6 +130,8 @@ case_live_runner_optional() {
   CLEANUP_PATHS+=("$bundle_root" "$summary_report")
 
   [[ -n "$final_verdict" ]] || return 1
+  [[ "$bundle_root" == *"/.harmony/output/reports/workflows/"* ]] || return 1
+  [[ "$bundle_root" != *"/.harmony/output/reports/audits/"* ]] || return 1
   assert_dir_exists "$bundle_root" || return 1
   assert_file_exists "$summary_report" || return 1
   assert_file_exists "$bundle_root/reports/01-design-package-audit.md" || return 1

--- a/.harmony/assurance/runtime/_ops/tests/test-validate-audit-convergence-contract.sh
+++ b/.harmony/assurance/runtime/_ops/tests/test-validate-audit-convergence-contract.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNTIME_DIR="$(cd "$OPS_DIR/.." && pwd)"
+ASSURANCE_DIR="$(cd "$RUNTIME_DIR/.." && pwd)"
+HARMONY_DIR="$(cd "$ASSURANCE_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$HARMONY_DIR/.." && pwd)"
+VALIDATE_SCRIPT=".harmony/assurance/runtime/_ops/scripts/validate-audit-convergence-contract.sh"
+
+pass_count=0
+fail_count=0
+cleanup_paths=()
+
+cleanup() {
+  local path
+  for path in "${cleanup_paths[@]}"; do
+    [[ -n "$path" ]] && rm -rf "$path"
+  done
+}
+trap cleanup EXIT
+
+pass() {
+  echo "PASS: $1"
+  pass_count=$((pass_count + 1))
+}
+
+fail() {
+  echo "FAIL: $1" >&2
+  fail_count=$((fail_count + 1))
+}
+
+assert_success() {
+  local name="$1"
+  shift
+  if "$@"; then
+    pass "$name"
+  else
+    fail "$name"
+  fi
+}
+
+assert_failure_contains() {
+  local name="$1"
+  local needle="$2"
+  shift 2
+
+  local output=""
+  local rc=0
+  output="$("$@" 2>&1)" || rc=$?
+
+  if (( rc != 0 )) && grep -Fq "$needle" <<<"$output"; then
+    pass "$name"
+    return 0
+  fi
+
+  fail "$name"
+  echo "  expected failure containing: $needle" >&2
+  echo "  exit code: $rc" >&2
+  echo "  output:" >&2
+  echo "$output" >&2
+  return 1
+}
+
+create_fixture_repo() {
+  local fixture_root bundle_dir
+  fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/audit-convergence-contract.XXXXXX")"
+  cleanup_paths+=("$fixture_root")
+
+  mkdir -p \
+    "$fixture_root/.harmony/assurance/runtime/_ops/scripts" \
+    "$fixture_root/.harmony/cognition/practices/methodology/audits" \
+    "$fixture_root/.harmony/cognition/runtime/audits" \
+    "$fixture_root/.harmony/output/reports/audits"
+
+  cp "$REPO_ROOT/$VALIDATE_SCRIPT" \
+    "$fixture_root/.harmony/assurance/runtime/_ops/scripts/validate-audit-convergence-contract.sh"
+
+  cat > "$fixture_root/.harmony/cognition/practices/methodology/audits/README.md" <<'EOF'
+# Bounded Audits
+EOF
+  cat > "$fixture_root/.harmony/cognition/practices/methodology/audits/index.yml" <<'EOF'
+schema_version: "audit-methodology-index-v1"
+artifacts: []
+EOF
+  cat > "$fixture_root/.harmony/cognition/practices/methodology/audits/doctrine.md" <<'EOF'
+# Doctrine
+EOF
+  cat > "$fixture_root/.harmony/cognition/practices/methodology/audits/invariants.md" <<'EOF'
+# Invariants
+EOF
+  cat > "$fixture_root/.harmony/cognition/practices/methodology/audits/exceptions.md" <<'EOF'
+# Exceptions
+EOF
+  cat > "$fixture_root/.harmony/cognition/practices/methodology/audits/ci-gates.md" <<'EOF'
+# CI Gates
+EOF
+  cat > "$fixture_root/.harmony/cognition/practices/methodology/audits/findings-contract.md" <<'EOF'
+# Findings Contract
+EOF
+
+  cat > "$fixture_root/.harmony/cognition/runtime/audits/README.md" <<'EOF'
+# Runtime Audits
+EOF
+  cat > "$fixture_root/.harmony/cognition/runtime/audits/index.yml" <<'EOF'
+schema_version: "audit-runtime-index-v1"
+records: []
+EOF
+
+  cat > "$fixture_root/.harmony/output/reports/audits/README.md" <<'EOF'
+# Audit Reports
+EOF
+
+  bundle_dir="$fixture_root/.harmony/output/reports/audits/2026-03-11-valid-bundle"
+  mkdir -p "$bundle_dir"
+
+  cat > "$bundle_dir/bundle.yml" <<'EOF'
+kind: audit-evidence-bundle
+id: 2026-03-11-valid-bundle
+findings: findings.yml
+coverage: coverage.yml
+convergence: convergence.yml
+evidence: evidence.md
+commands: commands.md
+validation: validation.md
+inventory: inventory.md
+EOF
+  cat > "$bundle_dir/findings.yml" <<'EOF'
+findings: []
+EOF
+  cat > "$bundle_dir/coverage.yml" <<'EOF'
+unaccounted_files: 0
+EOF
+  cat > "$bundle_dir/convergence.yml" <<'EOF'
+run_id: "run-001"
+commit_sha: "abc123"
+scope_hash: "scope-hash"
+prompt_hash: "prompt-hash"
+findings_hash: "findings-hash"
+params_hash: "params-hash"
+seed_unsupported: true
+fingerprint_unsupported: true
+stable: true
+union_blocking_findings: 0
+open_findings_at_or_above_threshold: 0
+done: true
+EOF
+  cat > "$bundle_dir/evidence.md" <<'EOF'
+# Evidence
+EOF
+  cat > "$bundle_dir/commands.md" <<'EOF'
+# Commands
+EOF
+  cat > "$bundle_dir/validation.md" <<'EOF'
+# Validation
+EOF
+  cat > "$bundle_dir/inventory.md" <<'EOF'
+# Inventory
+EOF
+
+  (
+    cd "$fixture_root"
+    git init >/dev/null
+    git add .harmony
+  )
+
+  printf '%s\n' "$fixture_root"
+}
+
+run_validator_in_fixture() {
+  local fixture_root="$1"
+  (
+    cd "$fixture_root"
+    bash "$VALIDATE_SCRIPT"
+  )
+}
+
+case_ignores_untracked_stale_workspace_dirs() {
+  local fixture_root
+  fixture_root="$(create_fixture_repo)"
+  mkdir -p \
+    "$fixture_root/.harmony/output/reports/audits/2026-03-08-architecture-validation-pipeline-smoke/reports" \
+    "$fixture_root/.harmony/output/reports/audits/2026-03-08-architecture-validation-pipeline-smoke/stage-inputs" \
+    "$fixture_root/.harmony/output/reports/audits/2026-03-08-architecture-validation-pipeline-smoke/stage-logs"
+  mkdir -p \
+    "$fixture_root/.harmony/output/reports/audits/2026-03-09-pipeline-design-package-smoke/reports" \
+    "$fixture_root/.harmony/output/reports/audits/2026-03-09-pipeline-design-package-smoke/stage-inputs" \
+    "$fixture_root/.harmony/output/reports/audits/2026-03-09-pipeline-design-package-smoke/stage-logs"
+  run_validator_in_fixture "$fixture_root"
+}
+
+case_tracked_partial_bundle_still_fails() {
+  local fixture_root broken_dir
+  fixture_root="$(create_fixture_repo)"
+  broken_dir="$fixture_root/.harmony/output/reports/audits/2026-03-08-pipeline-smoke"
+  mkdir -p "$broken_dir/reports"
+  cat > "$broken_dir/reports/01-stage.md" <<'EOF'
+# Partial Report
+EOF
+  (
+    cd "$fixture_root"
+    git add ".harmony/output/reports/audits/2026-03-08-pipeline-smoke/reports/01-stage.md"
+  )
+  run_validator_in_fixture "$fixture_root"
+}
+
+case_materialized_untracked_bundle_fails() {
+  local fixture_root broken_dir
+  fixture_root="$(create_fixture_repo)"
+  broken_dir="$fixture_root/.harmony/output/reports/audits/2026-03-09-pipeline-design-package-smoke"
+  mkdir -p "$broken_dir"
+  cat > "$broken_dir/bundle.yml" <<'EOF'
+kind: audit-evidence-bundle
+id: 2026-03-09-pipeline-design-package-smoke
+findings: findings.yml
+coverage: coverage.yml
+convergence: convergence.yml
+evidence: evidence.md
+commands: commands.md
+validation: validation.md
+inventory: inventory.md
+EOF
+  run_validator_in_fixture "$fixture_root"
+}
+
+main() {
+  assert_success \
+    "audit convergence validator ignores untracked stale workspace directories" \
+    case_ignores_untracked_stale_workspace_dirs
+
+  assert_failure_contains \
+    "audit convergence validator still rejects tracked partial bundles" \
+    "bundle missing metadata file: .harmony/output/reports/audits/2026-03-08-pipeline-smoke/bundle.yml" \
+    case_tracked_partial_bundle_still_fails
+
+  assert_failure_contains \
+    "audit convergence validator rejects materialized untracked bundles missing required files" \
+    "bundle missing required file (findings.yml): .harmony/output/reports/audits/2026-03-09-pipeline-design-package-smoke" \
+    case_materialized_untracked_bundle_fails
+
+  echo
+  echo "Passed: $pass_count"
+  echo "Failed: $fail_count"
+
+  if (( fail_count > 0 )); then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/.harmony/capabilities/runtime/commands/studio.md
+++ b/.harmony/capabilities/runtime/commands/studio.md
@@ -1,6 +1,6 @@
 ---
 title: Launch Studio
-description: Launch Harmony Studio for workflow graph design, inspection, and safe staged edits.
+description: Launch Harmony Studio for workflow graph design, read-only orchestration operations, and safe staged edits.
 access: agent
 argument-hint: "[--root <project-root>]"
 ---
@@ -43,6 +43,16 @@ When `studio` is invoked, the launcher uses source mode to avoid stale prebuilt 
 - Opens the `harmony_studio` desktop window
 - Loads workflows from `.harmony/orchestration/runtime/workflows/`
 - Enables graph inspection, staged edit buffer, patch preview export, and apply audit browsing
+- Enables a read-only `Operations` workspace for:
+  - overview
+  - lookup
+  - runs
+  - incidents
+  - queue
+  - watchers
+  - automations
+  - missions
+  - playbooks
 
 ## References
 

--- a/.harmony/catalog.md
+++ b/.harmony/catalog.md
@@ -110,7 +110,7 @@ Atomic operations in `capabilities/runtime/commands/`:
 | Command | Access | Description |
 |---------|--------|-------------|
 | [init.md](./capabilities/runtime/commands/init.md) | human | Initialize canonical `.harmony` bootstrap files plus repo-root ingress adapters (`.harmony/AGENTS.md`, `.harmony/OBJECTIVE.md`, `intent.contract.yml`, root `AGENTS.md`, root `CLAUDE.md`, `alignment-check`, optional `BOOT*.md`) |
-| [studio.md](./capabilities/runtime/commands/studio.md) | human | Launch Harmony Studio for workflow graph design, inspection, and safe staged edits |
+| [studio.md](./capabilities/runtime/commands/studio.md) | human | Launch Harmony Studio for workflow graph design, read-only orchestration operations, and safe staged edits |
 | [recover.md](./capabilities/runtime/commands/recover.md) | human | Recovery procedures for common agent failure modes |
 | [audit-skills-system-expansion.md](./capabilities/runtime/commands/audit-skills-system-expansion.md) | human | Invoke the skills-system expansion evaluation prompt through a slash-style command wrapper |
 | [alignment-check.md](./capabilities/runtime/commands/alignment-check.md) | human | Run profile-based alignment checks across harness aspects |

--- a/.harmony/engine/runtime/README.md
+++ b/.harmony/engine/runtime/README.md
@@ -10,3 +10,16 @@
 - `config/`: runtime-local configuration (including `policy-interface.yml`)
 - `spec/`: runtime schema/protocol contracts
 - `wit/`: canonical WIT contracts
+
+## Operator Surfaces
+
+The engine runtime now exposes orchestration operator inspection through the
+shared `harmony` CLI and Studio host:
+
+- `harmony orchestration lookup ...`
+- `harmony orchestration summary --surface ...`
+- `harmony orchestration incident closure-readiness --incident-id <id>`
+- `.harmony/engine/runtime/run studio`
+
+These are read-only operator surfaces over canonical orchestration and
+continuity artifacts. They do not create new execution authority.

--- a/.harmony/engine/runtime/crates/Cargo.lock
+++ b/.harmony/engine/runtime/crates/Cargo.lock
@@ -2443,6 +2443,7 @@ name = "harmony_studio"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "harmony_core",
  "serde",
  "serde_yaml",
  "slint",

--- a/.harmony/engine/runtime/crates/Cargo.toml
+++ b/.harmony/engine/runtime/crates/Cargo.toml
@@ -26,7 +26,7 @@ walkdir = "2"
 sha2 = "0.10"
 hex = "0.4"
 semver = "1"
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
 

--- a/.harmony/engine/runtime/crates/core/src/lib.rs
+++ b/.harmony/engine/runtime/crates/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod discovery;
 pub mod errors;
 pub mod jsonlines;
 pub mod limits;
+pub mod orchestration;
 pub mod policy;
 pub mod registry;
 pub mod root;

--- a/.harmony/engine/runtime/crates/core/src/orchestration.rs
+++ b/.harmony/engine/runtime/crates/core/src/orchestration.rs
@@ -1842,7 +1842,7 @@ fn parse_last_timeline_timestamp(path: &Path) -> Result<Option<String>> {
     for line in text.lines().rev() {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix("- ") {
-            if let Some((timestamp, _)) = rest.split_once(':') {
+            if let Some((timestamp, _)) = rest.split_once(": ") {
                 if timestamp.contains('T') {
                     return Ok(Some(timestamp.to_string()));
                 }
@@ -2046,6 +2046,10 @@ mod tests {
         assert_eq!(snapshot.automations[0].suppression_count, 2);
         assert_eq!(snapshot.missions[0].blocked_task_count, 1);
         assert_eq!(snapshot.incidents[0].closure_ready, true);
+        assert_eq!(
+            snapshot.incidents[0].last_timeline_update_at.as_deref(),
+            Some("2026-03-11T10:20:00Z")
+        );
 
         let _ = fs::remove_file("/tmp/harmony-orch-event.json");
         fs::remove_dir_all(root).ok();

--- a/.harmony/engine/runtime/crates/core/src/orchestration.rs
+++ b/.harmony/engine/runtime/crates/core/src/orchestration.rs
@@ -1,0 +1,2077 @@
+use crate::errors::{ErrorCode, KernelError, Result};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub enum SummarySurface {
+    Watchers,
+    Queue,
+    Automations,
+    Runs,
+    Missions,
+    Incidents,
+    All,
+}
+
+impl SummarySurface {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Watchers => "watchers",
+            Self::Queue => "queue",
+            Self::Automations => "automations",
+            Self::Runs => "runs",
+            Self::Missions => "missions",
+            Self::Incidents => "incidents",
+            Self::All => "all",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum LookupQuery {
+    DecisionId(String),
+    RunId(String),
+    IncidentId(String),
+    QueueItemId(String),
+    EventId(String),
+    AutomationId(String),
+    WatcherId(String),
+    MissionId(String),
+}
+
+impl LookupQuery {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::DecisionId(_) => "decision_id",
+            Self::RunId(_) => "run_id",
+            Self::IncidentId(_) => "incident_id",
+            Self::QueueItemId(_) => "queue_item_id",
+            Self::EventId(_) => "event_id",
+            Self::AutomationId(_) => "automation_id",
+            Self::WatcherId(_) => "watcher_id",
+            Self::MissionId(_) => "mission_id",
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        match self {
+            Self::DecisionId(id)
+            | Self::RunId(id)
+            | Self::IncidentId(id)
+            | Self::QueueItemId(id)
+            | Self::EventId(id)
+            | Self::AutomationId(id)
+            | Self::WatcherId(id)
+            | Self::MissionId(id) => id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct OverviewCounts {
+    pub watcher_count: usize,
+    pub watcher_unhealthy_count: usize,
+    pub automation_count: usize,
+    pub automation_attention_count: usize,
+    pub mission_count: usize,
+    pub run_count: usize,
+    pub running_run_count: usize,
+    pub incident_count: usize,
+    pub open_incident_count: usize,
+    pub incident_closure_blocked_count: usize,
+    pub queue_pending_count: usize,
+    pub queue_claimed_count: usize,
+    pub queue_retry_count: usize,
+    pub queue_dead_letter_count: usize,
+    pub queue_expired_claim_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QueueSummary {
+    pub pending_count: usize,
+    pub claimed_count: usize,
+    pub retry_count: usize,
+    pub dead_letter_count: usize,
+    pub expired_claim_count: usize,
+    pub oldest_pending_queue_item_id: Option<String>,
+    pub oldest_pending_age_seconds: Option<i64>,
+    pub last_receipt_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WatcherStatusSummary {
+    pub watcher_id: String,
+    pub title: String,
+    pub status: String,
+    pub health_status: String,
+    pub owner: String,
+    pub last_evaluated_at: Option<String>,
+    pub last_emitted_event_id: Option<String>,
+    pub last_emitted_at: Option<String>,
+    pub suppressed_count: usize,
+    pub health_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AutomationStatusSummary {
+    pub automation_id: String,
+    pub title: String,
+    pub status: String,
+    pub workflow_ref: Option<String>,
+    pub owner: String,
+    pub last_launch_attempt_at: Option<String>,
+    pub last_successful_run_id: Option<String>,
+    pub failure_count: usize,
+    pub suppression_count: usize,
+    pub pause_or_error_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunStatusSummary {
+    pub run_id: String,
+    pub status: String,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub recovery_status: Option<String>,
+    pub recovery_reason: Option<String>,
+    pub decision_link_health: String,
+    pub evidence_link_health: String,
+    pub workflow_ref: Option<String>,
+    pub mission_id: Option<String>,
+    pub automation_id: Option<String>,
+    pub incident_id: Option<String>,
+    pub queue_item_id: Option<String>,
+    pub event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MissionStatusSummary {
+    pub mission_id: String,
+    pub title: String,
+    pub status: String,
+    pub owner: String,
+    pub active_run_ids: Vec<String>,
+    pub blocked_task_count: usize,
+    pub outstanding_task_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IncidentStatusSummary {
+    pub incident_id: String,
+    pub title: String,
+    pub severity: String,
+    pub status: String,
+    pub owner: String,
+    pub last_timeline_update_at: Option<String>,
+    pub linked_run_ids: Vec<String>,
+    pub closure_ready: bool,
+    pub closure_blockers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OpsSnapshot {
+    pub generated_at: String,
+    pub overview: OverviewCounts,
+    pub watchers: Vec<WatcherStatusSummary>,
+    pub queue: QueueSummary,
+    pub automations: Vec<AutomationStatusSummary>,
+    pub runs: Vec<RunStatusSummary>,
+    pub missions: Vec<MissionStatusSummary>,
+    pub incidents: Vec<IncidentStatusSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SurfaceSummary {
+    pub generated_at: String,
+    pub surface: String,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ClosureReadiness {
+    pub incident_id: String,
+    pub title: String,
+    pub severity: String,
+    pub status: String,
+    pub owner: String,
+    pub linked_run_ids: Vec<String>,
+    pub ready: bool,
+    pub blockers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LookupArtifact {
+    pub kind: String,
+    pub id: String,
+    pub path: String,
+    pub status: Option<String>,
+    pub summary: Option<String>,
+    pub details: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LookupRelation {
+    pub from: String,
+    pub to: String,
+    pub relation: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LookupResult {
+    pub query_kind: String,
+    pub query_id: String,
+    pub artifacts: Vec<LookupArtifact>,
+    pub relations: Vec<LookupRelation>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OrchestrationInspector {
+    repo_root: PathBuf,
+    runtime_dir: PathBuf,
+    runs: Vec<RunRecord>,
+    decisions: Vec<DecisionRecord>,
+    queue_items: Vec<QueueItemRecord>,
+    queue_receipts: Vec<QueueReceiptRecord>,
+    watchers: Vec<WatcherRecord>,
+    automations: Vec<AutomationRecord>,
+    missions: Vec<MissionRecord>,
+    incidents: Vec<IncidentRecord>,
+}
+
+#[derive(Debug, Clone)]
+struct RunRecord {
+    run_id: String,
+    path: String,
+    status: String,
+    summary: Option<String>,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+    decision_id: Option<String>,
+    continuity_run_path: Option<String>,
+    recovery_status: Option<String>,
+    recovery_reason: Option<String>,
+    workflow_ref: Option<String>,
+    mission_id: Option<String>,
+    automation_id: Option<String>,
+    incident_id: Option<String>,
+    queue_item_id: Option<String>,
+    event_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct DecisionRecord {
+    decision_id: String,
+    path: String,
+    outcome: String,
+    summary: Option<String>,
+    run_id: Option<String>,
+    mission_id: Option<String>,
+    automation_id: Option<String>,
+    incident_id: Option<String>,
+    event_id: Option<String>,
+    queue_item_id: Option<String>,
+    workflow_ref: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct QueueItemRecord {
+    queue_item_id: String,
+    path: String,
+    lane: String,
+    status: String,
+    summary: Option<String>,
+    target_automation_id: Option<String>,
+    event_id: Option<String>,
+    watcher_id: Option<String>,
+    payload_ref: Option<String>,
+    enqueued_at: Option<String>,
+    claim_deadline: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct QueueReceiptRecord {
+    handled_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct WatcherRecord {
+    watcher_id: String,
+    path: String,
+    title: String,
+    owner: String,
+    status: String,
+    health_status: String,
+    health_reason: Option<String>,
+    last_evaluated_at: Option<String>,
+    suppressed_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct AutomationRecord {
+    automation_id: String,
+    path: String,
+    title: String,
+    owner: String,
+    status: String,
+    workflow_ref: Option<String>,
+    state_status: Option<String>,
+    state_reason: Option<String>,
+    counters_blocked: usize,
+}
+
+#[derive(Debug, Clone)]
+struct MissionRecord {
+    mission_id: String,
+    path: String,
+    title: String,
+    status: String,
+    owner: String,
+    active_run_ids: Vec<String>,
+    blocked_task_count: usize,
+    outstanding_task_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct IncidentRecord {
+    incident_id: String,
+    path: String,
+    title: String,
+    severity: String,
+    status: String,
+    owner: String,
+    summary: Option<String>,
+    linked_run_ids: Vec<String>,
+    last_timeline_update_at: Option<String>,
+}
+
+impl OrchestrationInspector {
+    pub fn from_harmony_dir(harmony_dir: &Path) -> Result<Self> {
+        let harmony_dir = harmony_dir.canonicalize().map_err(|e| {
+            KernelError::new(
+                ErrorCode::Internal,
+                format!("failed to canonicalize harmony dir {}: {e}", harmony_dir.display()),
+            )
+        })?;
+        let repo_root = harmony_dir
+            .parent()
+            .ok_or_else(|| KernelError::new(ErrorCode::Internal, ".harmony has no repository root"))?
+            .to_path_buf();
+        let runtime_dir = harmony_dir.join("orchestration").join("runtime");
+        let continuity_dir = harmony_dir.join("continuity");
+
+        Ok(Self {
+            runs: load_runs(&repo_root, &runtime_dir)?,
+            decisions: load_decisions(&repo_root, &continuity_dir)?,
+            queue_items: load_queue_items(&repo_root, &runtime_dir)?,
+            queue_receipts: load_queue_receipts(&repo_root, &runtime_dir)?,
+            watchers: load_watchers(&repo_root, &runtime_dir)?,
+            automations: load_automations(&repo_root, &runtime_dir)?,
+            missions: load_missions(&repo_root, &runtime_dir)?,
+            incidents: load_incidents(&repo_root, &runtime_dir)?,
+            repo_root,
+            runtime_dir,
+        })
+    }
+
+    pub fn from_repo_root(repo_root: &Path) -> Result<Self> {
+        Self::from_harmony_dir(&repo_root.join(".harmony"))
+    }
+
+    pub fn snapshot(&self) -> Result<OpsSnapshot> {
+        let generated_at = now_utc()?;
+        let watcher_summaries = self.watcher_summaries();
+        let queue_summary = self.queue_summary();
+        let automation_summaries = self.automation_summaries();
+        let run_summaries = self.run_summaries();
+        let mission_summaries = self.mission_summaries();
+        let incident_summaries = self.incident_summaries()?;
+
+        let overview = OverviewCounts {
+            watcher_count: watcher_summaries.len(),
+            watcher_unhealthy_count: watcher_summaries
+                .iter()
+                .filter(|item| item.health_status != "healthy")
+                .count(),
+            automation_count: automation_summaries.len(),
+            automation_attention_count: automation_summaries
+                .iter()
+                .filter(|item| {
+                    matches!(item.status.as_str(), "paused" | "error")
+                        || item.pause_or_error_reason.is_some()
+                        || item.failure_count > 0
+                })
+                .count(),
+            mission_count: mission_summaries.len(),
+            run_count: run_summaries.len(),
+            running_run_count: run_summaries
+                .iter()
+                .filter(|item| item.status == "running")
+                .count(),
+            incident_count: incident_summaries.len(),
+            open_incident_count: incident_summaries
+                .iter()
+                .filter(|item| item.status != "closed" && item.status != "cancelled")
+                .count(),
+            incident_closure_blocked_count: incident_summaries
+                .iter()
+                .filter(|item| !item.closure_ready)
+                .count(),
+            queue_pending_count: queue_summary.pending_count,
+            queue_claimed_count: queue_summary.claimed_count,
+            queue_retry_count: queue_summary.retry_count,
+            queue_dead_letter_count: queue_summary.dead_letter_count,
+            queue_expired_claim_count: queue_summary.expired_claim_count,
+        };
+
+        Ok(OpsSnapshot {
+            generated_at,
+            overview,
+            watchers: watcher_summaries,
+            queue: queue_summary,
+            automations: automation_summaries,
+            runs: run_summaries,
+            missions: mission_summaries,
+            incidents: incident_summaries,
+        })
+    }
+
+    pub fn summary(&self, surface: SummarySurface) -> Result<SurfaceSummary> {
+        let snapshot = self.snapshot()?;
+        let payload = match surface {
+            SummarySurface::Watchers => to_json_value(&snapshot.watchers)?,
+            SummarySurface::Queue => to_json_value(&snapshot.queue)?,
+            SummarySurface::Automations => to_json_value(&snapshot.automations)?,
+            SummarySurface::Runs => to_json_value(&snapshot.runs)?,
+            SummarySurface::Missions => to_json_value(&snapshot.missions)?,
+            SummarySurface::Incidents => to_json_value(&snapshot.incidents)?,
+            SummarySurface::All => to_json_value(&snapshot)?,
+        };
+
+        Ok(SurfaceSummary {
+            generated_at: snapshot.generated_at,
+            surface: surface.as_str().to_string(),
+            payload,
+        })
+    }
+
+    pub fn incident_closure_readiness(&self, incident_id: &str) -> Result<ClosureReadiness> {
+        let incident = self
+            .incidents
+            .iter()
+            .find(|item| item.incident_id == incident_id)
+            .ok_or_else(|| {
+                KernelError::new(
+                    ErrorCode::UnknownOperation,
+                    format!("unknown incident_id '{}'", incident_id),
+                )
+            })?;
+        compute_incident_closure_readiness(&self.repo_root, incident)
+    }
+
+    pub fn lookup(&self, query: LookupQuery) -> Result<LookupResult> {
+        let mut artifacts = Vec::new();
+        let mut relations = Vec::new();
+        let mut notes = Vec::new();
+        let mut seen = BTreeSet::new();
+
+        let mut push_artifact = |artifact: LookupArtifact| {
+            let key = format!("{}:{}", artifact.kind, artifact.id);
+            if seen.insert(key) {
+                artifacts.push(artifact);
+            }
+        };
+
+        match query.clone() {
+            LookupQuery::DecisionId(decision_id) => {
+                let decision = self
+                    .decisions
+                    .iter()
+                    .find(|item| item.decision_id == decision_id)
+                    .ok_or_else(|| {
+                        KernelError::new(
+                            ErrorCode::UnknownOperation,
+                            format!("unknown decision_id '{}'", query.id()),
+                        )
+                    })?;
+                push_artifact(self.decision_artifact(decision));
+                self.expand_from_decision(decision, &mut push_artifact, &mut relations, &mut notes);
+            }
+            LookupQuery::RunId(run_id) => {
+                let run = self.runs.iter().find(|item| item.run_id == run_id).ok_or_else(|| {
+                    KernelError::new(
+                        ErrorCode::UnknownOperation,
+                        format!("unknown run_id '{}'", query.id()),
+                    )
+                })?;
+                push_artifact(self.run_artifact(run));
+                self.expand_from_run(run, &mut push_artifact, &mut relations, &mut notes);
+            }
+            LookupQuery::IncidentId(incident_id) => {
+                let incident = self
+                    .incidents
+                    .iter()
+                    .find(|item| item.incident_id == incident_id)
+                    .ok_or_else(|| {
+                        KernelError::new(
+                            ErrorCode::UnknownOperation,
+                            format!("unknown incident_id '{}'", query.id()),
+                        )
+                    })?;
+                push_artifact(self.incident_artifact(incident)?);
+                self.expand_from_incident(incident, &mut push_artifact, &mut relations, &mut notes)?;
+            }
+            LookupQuery::QueueItemId(queue_item_id) => {
+                let queue_item = self
+                    .queue_items
+                    .iter()
+                    .find(|item| item.queue_item_id == queue_item_id)
+                    .ok_or_else(|| {
+                        KernelError::new(
+                            ErrorCode::UnknownOperation,
+                            format!("unknown queue_item_id '{}'", query.id()),
+                        )
+                    })?;
+                push_artifact(self.queue_artifact(queue_item));
+                self.expand_from_queue_item(queue_item, &mut push_artifact, &mut relations, &mut notes);
+            }
+            LookupQuery::EventId(event_id) => {
+                let mut found = false;
+                for queue_item in self.queue_items.iter().filter(|item| item.event_id.as_deref() == Some(event_id.as_str())) {
+                    found = true;
+                    push_artifact(self.queue_artifact(queue_item));
+                    self.expand_from_queue_item(queue_item, &mut push_artifact, &mut relations, &mut notes);
+                }
+                for run in self.runs.iter().filter(|item| item.event_id.as_deref() == Some(event_id.as_str())) {
+                    found = true;
+                    push_artifact(self.run_artifact(run));
+                    self.expand_from_run(run, &mut push_artifact, &mut relations, &mut notes);
+                }
+                for decision in self
+                    .decisions
+                    .iter()
+                    .filter(|item| item.event_id.as_deref() == Some(event_id.as_str()))
+                {
+                    found = true;
+                    push_artifact(self.decision_artifact(decision));
+                    self.expand_from_decision(decision, &mut push_artifact, &mut relations, &mut notes);
+                }
+                for incident in self
+                    .incidents
+                    .iter()
+                    .filter(|item| incident_contains_event(item, event_id.as_str(), &self.repo_root))
+                {
+                    found = true;
+                    push_artifact(self.incident_artifact(incident)?);
+                    self.expand_from_incident(incident, &mut push_artifact, &mut relations, &mut notes)?;
+                }
+                if !found {
+                    return Err(KernelError::new(
+                        ErrorCode::UnknownOperation,
+                        format!("unknown event_id '{}'", query.id()),
+                    ));
+                }
+            }
+            LookupQuery::AutomationId(automation_id) => {
+                let automation = self
+                    .automations
+                    .iter()
+                    .find(|item| item.automation_id == automation_id)
+                    .ok_or_else(|| {
+                        KernelError::new(
+                            ErrorCode::UnknownOperation,
+                            format!("unknown automation_id '{}'", query.id()),
+                        )
+                    })?;
+                push_artifact(self.automation_artifact(automation));
+                for queue_item in self
+                    .queue_items
+                    .iter()
+                    .filter(|item| item.target_automation_id.as_deref() == Some(automation_id.as_str()))
+                {
+                    push_artifact(self.queue_artifact(queue_item));
+                    relations.push(LookupRelation {
+                        from: format!("queue_item:{}", queue_item.queue_item_id),
+                        to: format!("automation:{}", automation_id),
+                        relation: "targets".to_string(),
+                    });
+                }
+                for run in self.runs.iter().filter(|item| item.automation_id.as_deref() == Some(automation_id.as_str())) {
+                    push_artifact(self.run_artifact(run));
+                    self.expand_from_run(run, &mut push_artifact, &mut relations, &mut notes);
+                }
+                if let Some(workflow_ref) = &automation.workflow_ref {
+                    push_artifact(self.workflow_artifact(workflow_ref));
+                    relations.push(LookupRelation {
+                        from: format!("automation:{}", automation_id),
+                        to: format!("workflow:{}", workflow_ref),
+                        relation: "targets_workflow".to_string(),
+                    });
+                }
+            }
+            LookupQuery::WatcherId(watcher_id) => {
+                let watcher = self
+                    .watchers
+                    .iter()
+                    .find(|item| item.watcher_id == watcher_id)
+                    .ok_or_else(|| {
+                        KernelError::new(
+                            ErrorCode::UnknownOperation,
+                            format!("unknown watcher_id '{}'", query.id()),
+                        )
+                    })?;
+                push_artifact(self.watcher_artifact(watcher));
+                for queue_item in self.queue_items.iter().filter(|item| item.watcher_id.as_deref() == Some(watcher_id.as_str())) {
+                    push_artifact(self.queue_artifact(queue_item));
+                    self.expand_from_queue_item(queue_item, &mut push_artifact, &mut relations, &mut notes);
+                }
+            }
+            LookupQuery::MissionId(mission_id) => {
+                let mission = self
+                    .missions
+                    .iter()
+                    .find(|item| item.mission_id == mission_id)
+                    .ok_or_else(|| {
+                        KernelError::new(
+                            ErrorCode::UnknownOperation,
+                            format!("unknown mission_id '{}'", query.id()),
+                        )
+                    })?;
+                push_artifact(self.mission_artifact(mission));
+                for run in self.runs.iter().filter(|item| item.mission_id.as_deref() == Some(mission_id.as_str())) {
+                    push_artifact(self.run_artifact(run));
+                    self.expand_from_run(run, &mut push_artifact, &mut relations, &mut notes);
+                }
+                for incident in self.incidents.iter().filter(|item| incident_contains_mission(item, mission_id.as_str(), &self.repo_root)) {
+                    push_artifact(self.incident_artifact(incident)?);
+                    self.expand_from_incident(incident, &mut push_artifact, &mut relations, &mut notes)?;
+                }
+            }
+        }
+
+        artifacts.sort_by(|a, b| a.kind.cmp(&b.kind).then(a.id.cmp(&b.id)));
+        relations.sort_by(|a, b| a.from.cmp(&b.from).then(a.to.cmp(&b.to)).then(a.relation.cmp(&b.relation)));
+        notes.sort();
+        notes.dedup();
+
+        Ok(LookupResult {
+            query_kind: query.kind().to_string(),
+            query_id: query.id().to_string(),
+            artifacts,
+            relations,
+            notes,
+        })
+    }
+
+    fn watcher_summaries(&self) -> Vec<WatcherStatusSummary> {
+        let mut items = self
+            .watchers
+            .iter()
+            .map(|watcher| {
+                let latest_event = self.latest_event_for_watcher(&watcher.watcher_id);
+                WatcherStatusSummary {
+                    watcher_id: watcher.watcher_id.clone(),
+                    title: watcher.title.clone(),
+                    status: watcher.status.clone(),
+                    health_status: watcher.health_status.clone(),
+                    owner: watcher.owner.clone(),
+                    last_evaluated_at: watcher.last_evaluated_at.clone(),
+                    last_emitted_event_id: latest_event.as_ref().map(|(event_id, _, _)| event_id.clone()),
+                    last_emitted_at: latest_event.as_ref().and_then(|(_, emitted_at, _)| emitted_at.clone()),
+                    suppressed_count: watcher.suppressed_count,
+                    health_reason: watcher.health_reason.clone(),
+                }
+            })
+            .collect::<Vec<_>>();
+        items.sort_by(|a, b| a.watcher_id.cmp(&b.watcher_id));
+        items
+    }
+
+    fn queue_summary(&self) -> QueueSummary {
+        let mut pending_count = 0;
+        let mut claimed_count = 0;
+        let mut retry_count = 0;
+        let mut dead_letter_count = 0;
+        let mut expired_claim_count = 0;
+        let mut oldest_pending: Option<(&QueueItemRecord, Option<OffsetDateTime>)> = None;
+        let now = OffsetDateTime::now_utc();
+
+        for item in &self.queue_items {
+            match item.lane.as_str() {
+                "pending" => {
+                    pending_count += 1;
+                    let parsed = item.enqueued_at.as_deref().and_then(parse_timestamp);
+                    match (&oldest_pending, parsed) {
+                        (None, _) => oldest_pending = Some((item, parsed)),
+                        (Some((current, current_ts)), Some(candidate_ts)) => {
+                            if current_ts.map(|ts| candidate_ts < ts).unwrap_or(true) {
+                                oldest_pending = Some((item, Some(candidate_ts)));
+                            } else {
+                                oldest_pending = Some((current, *current_ts));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                "claimed" => {
+                    claimed_count += 1;
+                    if item
+                        .claim_deadline
+                        .as_deref()
+                        .and_then(parse_timestamp)
+                        .map(|deadline| deadline < now)
+                        .unwrap_or(false)
+                    {
+                        expired_claim_count += 1;
+                    }
+                }
+                "retry" => retry_count += 1,
+                "dead-letter" => dead_letter_count += 1,
+                _ => {}
+            }
+        }
+
+        let oldest_pending_queue_item_id = oldest_pending.map(|(item, _)| item.queue_item_id.clone());
+        let oldest_pending_age_seconds = oldest_pending
+            .and_then(|(_, ts)| ts)
+            .map(|ts| (now - ts).whole_seconds());
+        let last_receipt_at = self
+            .queue_receipts
+            .iter()
+            .filter_map(|item| item.handled_at.clone())
+            .max();
+
+        QueueSummary {
+            pending_count,
+            claimed_count,
+            retry_count,
+            dead_letter_count,
+            expired_claim_count,
+            oldest_pending_queue_item_id,
+            oldest_pending_age_seconds,
+            last_receipt_at,
+        }
+    }
+
+    fn automation_summaries(&self) -> Vec<AutomationStatusSummary> {
+        let mut items = self
+            .automations
+            .iter()
+            .map(|automation| {
+                let related_runs = self
+                    .runs
+                    .iter()
+                    .filter(|run| run.automation_id.as_deref() == Some(automation.automation_id.as_str()))
+                    .collect::<Vec<_>>();
+                let last_launch_attempt_at = related_runs
+                    .iter()
+                    .filter_map(|run| run.started_at.clone())
+                    .max();
+                let last_successful_run_id = related_runs
+                    .iter()
+                    .filter(|run| run.status == "succeeded")
+                    .max_by_key(|run| run.completed_at.clone().unwrap_or_default())
+                    .map(|run| run.run_id.clone());
+                let failure_count = related_runs.iter().filter(|run| run.status == "failed").count();
+                let pause_or_error_reason = automation.state_reason.clone().or_else(|| {
+                    if matches!(automation.status.as_str(), "paused" | "error") {
+                        Some("status requires operator attention".to_string())
+                    } else {
+                        None
+                    }
+                });
+                AutomationStatusSummary {
+                    automation_id: automation.automation_id.clone(),
+                    title: automation.title.clone(),
+                    status: automation
+                        .state_status
+                        .clone()
+                        .unwrap_or_else(|| automation.status.clone()),
+                    workflow_ref: automation.workflow_ref.clone(),
+                    owner: automation.owner.clone(),
+                    last_launch_attempt_at,
+                    last_successful_run_id,
+                    failure_count,
+                    suppression_count: automation.counters_blocked,
+                    pause_or_error_reason,
+                }
+            })
+            .collect::<Vec<_>>();
+        items.sort_by(|a, b| a.automation_id.cmp(&b.automation_id));
+        items
+    }
+
+    fn run_summaries(&self) -> Vec<RunStatusSummary> {
+        let mut items = self
+            .runs
+            .iter()
+            .map(|run| {
+                let decision_link_health = match &run.decision_id {
+                    Some(decision_id) if self.decisions.iter().any(|item| item.decision_id == *decision_id) => "healthy".to_string(),
+                    Some(_) => "missing-decision".to_string(),
+                    None => "missing-decision".to_string(),
+                };
+                let evidence_link_health = match &run.continuity_run_path {
+                    Some(path) if self.repo_root.join(path).exists() => "healthy".to_string(),
+                    Some(_) => "missing-continuity-evidence".to_string(),
+                    None => "missing-continuity-evidence".to_string(),
+                };
+                RunStatusSummary {
+                    run_id: run.run_id.clone(),
+                    status: run.status.clone(),
+                    started_at: run.started_at.clone(),
+                    completed_at: run.completed_at.clone(),
+                    recovery_status: run.recovery_status.clone(),
+                    recovery_reason: run.recovery_reason.clone(),
+                    decision_link_health,
+                    evidence_link_health,
+                    workflow_ref: run.workflow_ref.clone(),
+                    mission_id: run.mission_id.clone(),
+                    automation_id: run.automation_id.clone(),
+                    incident_id: run.incident_id.clone(),
+                    queue_item_id: run.queue_item_id.clone(),
+                    event_id: run.event_id.clone(),
+                }
+            })
+            .collect::<Vec<_>>();
+        items.sort_by(|a, b| a.run_id.cmp(&b.run_id));
+        items
+    }
+
+    fn mission_summaries(&self) -> Vec<MissionStatusSummary> {
+        let mut items = self
+            .missions
+            .iter()
+            .map(|mission| MissionStatusSummary {
+                mission_id: mission.mission_id.clone(),
+                title: mission.title.clone(),
+                status: mission.status.clone(),
+                owner: mission.owner.clone(),
+                active_run_ids: mission.active_run_ids.clone(),
+                blocked_task_count: mission.blocked_task_count,
+                outstanding_task_count: mission.outstanding_task_count,
+            })
+            .collect::<Vec<_>>();
+        items.sort_by(|a, b| a.mission_id.cmp(&b.mission_id));
+        items
+    }
+
+    fn incident_summaries(&self) -> Result<Vec<IncidentStatusSummary>> {
+        let mut items = Vec::new();
+        for incident in &self.incidents {
+            let readiness = compute_incident_closure_readiness(&self.repo_root, incident)?;
+            items.push(IncidentStatusSummary {
+                incident_id: incident.incident_id.clone(),
+                title: incident.title.clone(),
+                severity: incident.severity.clone(),
+                status: incident.status.clone(),
+                owner: incident.owner.clone(),
+                last_timeline_update_at: incident.last_timeline_update_at.clone(),
+                linked_run_ids: incident.linked_run_ids.clone(),
+                closure_ready: readiness.ready,
+                closure_blockers: readiness.blockers,
+            });
+        }
+        items.sort_by(|a, b| a.incident_id.cmp(&b.incident_id));
+        Ok(items)
+    }
+
+    fn latest_event_for_watcher(&self, watcher_id: &str) -> Option<(String, Option<String>, String)> {
+        self.queue_items
+            .iter()
+            .filter(|item| item.watcher_id.as_deref() == Some(watcher_id))
+            .filter_map(|item| {
+                let emitted_at = item
+                    .payload_ref
+                    .as_deref()
+                    .and_then(|path| read_event_timestamp(&self.repo_root, path).ok().flatten());
+                Some((
+                    item.event_id.clone().unwrap_or_else(|| item.queue_item_id.clone()),
+                    emitted_at,
+                    item.path.clone(),
+                ))
+            })
+            .max_by_key(|(event_id, emitted_at, path)| {
+                (
+                    emitted_at.clone().unwrap_or_default(),
+                    event_id.clone(),
+                    path.clone(),
+                )
+            })
+    }
+
+    fn decision_artifact(&self, item: &DecisionRecord) -> LookupArtifact {
+        let mut details = BTreeMap::new();
+        details.insert("outcome".to_string(), item.outcome.clone());
+        if let Some(workflow_ref) = &item.workflow_ref {
+            details.insert("workflow_ref".to_string(), workflow_ref.clone());
+        }
+        LookupArtifact {
+            kind: "decision".to_string(),
+            id: item.decision_id.clone(),
+            path: item.path.clone(),
+            status: Some(item.outcome.clone()),
+            summary: item.summary.clone(),
+            details,
+        }
+    }
+
+    fn run_artifact(&self, item: &RunRecord) -> LookupArtifact {
+        let mut details = BTreeMap::new();
+        if let Some(workflow_ref) = &item.workflow_ref {
+            details.insert("workflow_ref".to_string(), workflow_ref.clone());
+        }
+        if let Some(recovery_status) = &item.recovery_status {
+            details.insert("recovery_status".to_string(), recovery_status.clone());
+        }
+        details.insert(
+            "decision_link_health".to_string(),
+            if item
+                .decision_id
+                .as_ref()
+                .is_some_and(|decision_id| self.decisions.iter().any(|entry| entry.decision_id == *decision_id))
+            {
+                "healthy".to_string()
+            } else {
+                "missing-decision".to_string()
+            },
+        );
+        details.insert(
+            "evidence_link_health".to_string(),
+            if item
+                .continuity_run_path
+                .as_ref()
+                .is_some_and(|path| self.repo_root.join(path).exists())
+            {
+                "healthy".to_string()
+            } else {
+                "missing-continuity-evidence".to_string()
+            },
+        );
+        LookupArtifact {
+            kind: "run".to_string(),
+            id: item.run_id.clone(),
+            path: item.path.clone(),
+            status: Some(item.status.clone()),
+            summary: item.summary.clone(),
+            details,
+        }
+    }
+
+    fn queue_artifact(&self, item: &QueueItemRecord) -> LookupArtifact {
+        let mut details = BTreeMap::new();
+        details.insert("lane".to_string(), item.lane.clone());
+        if let Some(target) = &item.target_automation_id {
+            details.insert("target_automation_id".to_string(), target.clone());
+        }
+        LookupArtifact {
+            kind: "queue_item".to_string(),
+            id: item.queue_item_id.clone(),
+            path: item.path.clone(),
+            status: Some(item.status.clone()),
+            summary: item.summary.clone(),
+            details,
+        }
+    }
+
+    fn watcher_artifact(&self, item: &WatcherRecord) -> LookupArtifact {
+        let mut details = BTreeMap::new();
+        details.insert("health_status".to_string(), item.health_status.clone());
+        if let Some(reason) = &item.health_reason {
+            details.insert("health_reason".to_string(), reason.clone());
+        }
+        LookupArtifact {
+            kind: "watcher".to_string(),
+            id: item.watcher_id.clone(),
+            path: item.path.clone(),
+            status: Some(item.status.clone()),
+            summary: Some(item.title.clone()),
+            details,
+        }
+    }
+
+    fn automation_artifact(&self, item: &AutomationRecord) -> LookupArtifact {
+        let mut details = BTreeMap::new();
+        if let Some(workflow_ref) = &item.workflow_ref {
+            details.insert("workflow_ref".to_string(), workflow_ref.clone());
+        }
+        LookupArtifact {
+            kind: "automation".to_string(),
+            id: item.automation_id.clone(),
+            path: item.path.clone(),
+            status: Some(item.status.clone()),
+            summary: Some(item.title.clone()),
+            details,
+        }
+    }
+
+    fn mission_artifact(&self, item: &MissionRecord) -> LookupArtifact {
+        let mut details = BTreeMap::new();
+        details.insert(
+            "outstanding_task_count".to_string(),
+            item.outstanding_task_count.to_string(),
+        );
+        details.insert("blocked_task_count".to_string(), item.blocked_task_count.to_string());
+        LookupArtifact {
+            kind: "mission".to_string(),
+            id: item.mission_id.clone(),
+            path: item.path.clone(),
+            status: Some(item.status.clone()),
+            summary: Some(item.title.clone()),
+            details,
+        }
+    }
+
+    fn incident_artifact(&self, item: &IncidentRecord) -> Result<LookupArtifact> {
+        let readiness = compute_incident_closure_readiness(&self.repo_root, item)?;
+        let mut details = BTreeMap::new();
+        details.insert("severity".to_string(), item.severity.clone());
+        details.insert("closure_ready".to_string(), readiness.ready.to_string());
+        if !readiness.blockers.is_empty() {
+            details.insert("closure_blockers".to_string(), readiness.blockers.join("; "));
+        }
+        Ok(LookupArtifact {
+            kind: "incident".to_string(),
+            id: item.incident_id.clone(),
+            path: item.path.clone(),
+            status: Some(item.status.clone()),
+            summary: item.summary.clone().or_else(|| Some(item.title.clone())),
+            details,
+        })
+    }
+
+    fn workflow_artifact(&self, workflow_ref: &str) -> LookupArtifact {
+        let parts = workflow_ref.split('/').collect::<Vec<_>>();
+        let path = if parts.len() == 2 {
+            self.runtime_dir
+                .join("workflows")
+                .join(parts[0])
+                .join(parts[1])
+                .join("workflow.yml")
+        } else {
+            self.runtime_dir.join("workflows")
+        };
+        LookupArtifact {
+            kind: "workflow".to_string(),
+            id: workflow_ref.to_string(),
+            path: rel_path(&self.repo_root, &path),
+            status: None,
+            summary: None,
+            details: BTreeMap::new(),
+        }
+    }
+
+    fn continuity_run_artifact(&self, path: &str, run_id: &str) -> LookupArtifact {
+        let abs = self.repo_root.join(path);
+        LookupArtifact {
+            kind: "continuity_run".to_string(),
+            id: run_id.to_string(),
+            path: rel_path(&self.repo_root, &abs),
+            status: Some(if abs.exists() { "present" } else { "missing" }.to_string()),
+            summary: None,
+            details: BTreeMap::new(),
+        }
+    }
+
+    fn expand_from_decision(
+        &self,
+        decision: &DecisionRecord,
+        push_artifact: &mut dyn FnMut(LookupArtifact),
+        relations: &mut Vec<LookupRelation>,
+        notes: &mut Vec<String>,
+    ) {
+        if let Some(run_id) = &decision.run_id {
+            if let Some(run) = self.runs.iter().find(|item| item.run_id == *run_id) {
+                push_artifact(self.run_artifact(run));
+                relations.push(LookupRelation {
+                    from: format!("decision:{}", decision.decision_id),
+                    to: format!("run:{}", run.run_id),
+                    relation: "permits".to_string(),
+                });
+                self.expand_from_run(run, push_artifact, relations, notes);
+            }
+        }
+        if let Some(queue_item_id) = &decision.queue_item_id {
+            if let Some(queue_item) = self
+                .queue_items
+                .iter()
+                .find(|item| item.queue_item_id == *queue_item_id)
+            {
+                push_artifact(self.queue_artifact(queue_item));
+                relations.push(LookupRelation {
+                    from: format!("decision:{}", decision.decision_id),
+                    to: format!("queue_item:{}", queue_item.queue_item_id),
+                    relation: "references_queue_item".to_string(),
+                });
+            }
+        }
+        if let Some(automation_id) = &decision.automation_id {
+            if let Some(automation) = self
+                .automations
+                .iter()
+                .find(|item| item.automation_id == *automation_id)
+            {
+                push_artifact(self.automation_artifact(automation));
+                relations.push(LookupRelation {
+                    from: format!("decision:{}", decision.decision_id),
+                    to: format!("automation:{}", automation.automation_id),
+                    relation: "for_automation".to_string(),
+                });
+            }
+        }
+        if let Some(mission_id) = &decision.mission_id {
+            if let Some(mission) = self.missions.iter().find(|item| item.mission_id == *mission_id) {
+                push_artifact(self.mission_artifact(mission));
+            }
+        }
+        if let Some(incident_id) = &decision.incident_id {
+            if let Some(incident) = self
+                .incidents
+                .iter()
+                .find(|item| item.incident_id == *incident_id)
+            {
+                if let Ok(artifact) = self.incident_artifact(incident) {
+                    push_artifact(artifact);
+                }
+            }
+        }
+        if let Some(workflow_ref) = &decision.workflow_ref {
+            push_artifact(self.workflow_artifact(workflow_ref));
+        }
+        if let Some(event_id) = &decision.event_id {
+            notes.push(format!("decision references event_id `{event_id}`"));
+        }
+    }
+
+    fn expand_from_run(
+        &self,
+        run: &RunRecord,
+        push_artifact: &mut dyn FnMut(LookupArtifact),
+        relations: &mut Vec<LookupRelation>,
+        notes: &mut Vec<String>,
+    ) {
+        if let Some(decision_id) = &run.decision_id {
+            if let Some(decision) = self
+                .decisions
+                .iter()
+                .find(|item| item.decision_id == *decision_id)
+            {
+                push_artifact(self.decision_artifact(decision));
+                relations.push(LookupRelation {
+                    from: format!("run:{}", run.run_id),
+                    to: format!("decision:{}", decision.decision_id),
+                    relation: "authorized_by".to_string(),
+                });
+            } else {
+                notes.push(format!("run `{}` references missing decision `{}`", run.run_id, decision_id));
+            }
+        }
+        if let Some(queue_item_id) = &run.queue_item_id {
+            if let Some(queue_item) = self
+                .queue_items
+                .iter()
+                .find(|item| item.queue_item_id == *queue_item_id)
+            {
+                push_artifact(self.queue_artifact(queue_item));
+                relations.push(LookupRelation {
+                    from: format!("run:{}", run.run_id),
+                    to: format!("queue_item:{}", queue_item.queue_item_id),
+                    relation: "originated_from".to_string(),
+                });
+            }
+        }
+        if let Some(automation_id) = &run.automation_id {
+            if let Some(automation) = self
+                .automations
+                .iter()
+                .find(|item| item.automation_id == *automation_id)
+            {
+                push_artifact(self.automation_artifact(automation));
+                relations.push(LookupRelation {
+                    from: format!("run:{}", run.run_id),
+                    to: format!("automation:{}", automation.automation_id),
+                    relation: "launched_by".to_string(),
+                });
+                if let Some(workflow_ref) = &automation.workflow_ref {
+                    push_artifact(self.workflow_artifact(workflow_ref));
+                }
+            }
+        }
+        if let Some(workflow_ref) = &run.workflow_ref {
+            push_artifact(self.workflow_artifact(workflow_ref));
+        }
+        if let Some(mission_id) = &run.mission_id {
+            if let Some(mission) = self.missions.iter().find(|item| item.mission_id == *mission_id) {
+                push_artifact(self.mission_artifact(mission));
+                relations.push(LookupRelation {
+                    from: format!("run:{}", run.run_id),
+                    to: format!("mission:{}", mission.mission_id),
+                    relation: "linked_to".to_string(),
+                });
+            }
+        }
+        if let Some(incident_id) = &run.incident_id {
+            if let Some(incident) = self
+                .incidents
+                .iter()
+                .find(|item| item.incident_id == *incident_id)
+            {
+                if let Ok(artifact) = self.incident_artifact(incident) {
+                    push_artifact(artifact);
+                }
+                relations.push(LookupRelation {
+                    from: format!("run:{}", run.run_id),
+                    to: format!("incident:{}", incident.incident_id),
+                    relation: "linked_to".to_string(),
+                });
+            }
+        }
+        if let Some(path) = &run.continuity_run_path {
+            push_artifact(self.continuity_run_artifact(path, &run.run_id));
+        }
+        if let Some(event_id) = &run.event_id {
+            notes.push(format!("run references event_id `{event_id}`"));
+        }
+    }
+
+    fn expand_from_queue_item(
+        &self,
+        queue_item: &QueueItemRecord,
+        push_artifact: &mut dyn FnMut(LookupArtifact),
+        relations: &mut Vec<LookupRelation>,
+        notes: &mut Vec<String>,
+    ) {
+        if let Some(automation_id) = &queue_item.target_automation_id {
+            if let Some(automation) = self
+                .automations
+                .iter()
+                .find(|item| item.automation_id == *automation_id)
+            {
+                push_artifact(self.automation_artifact(automation));
+                relations.push(LookupRelation {
+                    from: format!("queue_item:{}", queue_item.queue_item_id),
+                    to: format!("automation:{}", automation.automation_id),
+                    relation: "targets".to_string(),
+                });
+                if let Some(workflow_ref) = &automation.workflow_ref {
+                    push_artifact(self.workflow_artifact(workflow_ref));
+                }
+            }
+        }
+        if let Some(watcher_id) = &queue_item.watcher_id {
+            if let Some(watcher) = self.watchers.iter().find(|item| item.watcher_id == *watcher_id) {
+                push_artifact(self.watcher_artifact(watcher));
+                relations.push(LookupRelation {
+                    from: format!("queue_item:{}", queue_item.queue_item_id),
+                    to: format!("watcher:{}", watcher.watcher_id),
+                    relation: "emitted_by".to_string(),
+                });
+            }
+        }
+        if let Some(event_id) = &queue_item.event_id {
+            for run in self.runs.iter().filter(|item| item.event_id.as_deref() == Some(event_id.as_str())) {
+                push_artifact(self.run_artifact(run));
+                relations.push(LookupRelation {
+                    from: format!("queue_item:{}", queue_item.queue_item_id),
+                    to: format!("run:{}", run.run_id),
+                    relation: "launches".to_string(),
+                });
+            }
+            notes.push(format!("queue item references event_id `{event_id}`"));
+        }
+    }
+
+    fn expand_from_incident(
+        &self,
+        incident: &IncidentRecord,
+        push_artifact: &mut dyn FnMut(LookupArtifact),
+        relations: &mut Vec<LookupRelation>,
+        notes: &mut Vec<String>,
+    ) -> Result<()> {
+            let readiness = compute_incident_closure_readiness(&self.repo_root, incident)?;
+        if !readiness.blockers.is_empty() {
+            notes.push(format!(
+                "incident `{}` closure blockers: {}",
+                incident.incident_id,
+                readiness.blockers.join("; ")
+            ));
+        }
+        for run_id in &incident.linked_run_ids {
+            if let Some(run) = self.runs.iter().find(|item| item.run_id == *run_id) {
+                push_artifact(self.run_artifact(run));
+                relations.push(LookupRelation {
+                    from: format!("incident:{}", incident.incident_id),
+                    to: format!("run:{}", run.run_id),
+                    relation: "tracks".to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn load_runs(repo_root: &Path, runtime_dir: &Path) -> Result<Vec<RunRecord>> {
+    let runs_dir = runtime_dir.join("runs");
+    if !runs_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut runs = Vec::new();
+    for entry in fs::read_dir(&runs_dir).map_err(|e| io_error("read orchestration runs dir", &runs_dir, e))? {
+        let entry = entry.map_err(|e| io_error("read orchestration runs dir entry", &runs_dir, e))?;
+        let path = entry.path();
+        if !path.is_file() || path.file_name().and_then(|v| v.to_str()) == Some("README.md") || path.file_name().and_then(|v| v.to_str()) == Some("index.yml") {
+            continue;
+        }
+        if path.extension().and_then(|v| v.to_str()) != Some("yml") {
+            continue;
+        }
+        let value = read_yaml_value(&path)?;
+        runs.push(RunRecord {
+            run_id: required_string(&value, "run_id", &path)?,
+            path: rel_path(repo_root, &path),
+            status: string_field(&value, "status").unwrap_or_else(|| "unknown".to_string()),
+            summary: string_field(&value, "summary"),
+            started_at: string_field(&value, "started_at"),
+            completed_at: string_field(&value, "completed_at"),
+            decision_id: string_field(&value, "decision_id"),
+            continuity_run_path: string_field(&value, "continuity_run_path"),
+            recovery_status: string_field(&value, "recovery_status"),
+            recovery_reason: string_field(&value, "recovery_reason"),
+            workflow_ref: workflow_ref_string(&value),
+            mission_id: string_field(&value, "mission_id"),
+            automation_id: string_field(&value, "automation_id"),
+            incident_id: string_field(&value, "incident_id"),
+            queue_item_id: string_field(&value, "queue_item_id"),
+            event_id: string_field(&value, "event_id"),
+        });
+    }
+    Ok(runs)
+}
+
+fn load_decisions(repo_root: &Path, continuity_dir: &Path) -> Result<Vec<DecisionRecord>> {
+    let decisions_dir = continuity_dir.join("decisions");
+    if !decisions_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut decisions = Vec::new();
+    for entry in fs::read_dir(&decisions_dir).map_err(|e| io_error("read decisions dir", &decisions_dir, e))? {
+        let entry = entry.map_err(|e| io_error("read decisions dir entry", &decisions_dir, e))?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let decision_path = path.join("decision.json");
+        if !decision_path.is_file() {
+            continue;
+        }
+        let value = read_json_value(&decision_path)?;
+        decisions.push(DecisionRecord {
+            decision_id: required_string(&value, "decision_id", &decision_path)?,
+            path: rel_path(repo_root, &decision_path),
+            outcome: string_field(&value, "outcome").unwrap_or_else(|| "unknown".to_string()),
+            summary: string_field(&value, "summary"),
+            run_id: string_field(&value, "run_id"),
+            mission_id: string_field(&value, "mission_id"),
+            automation_id: string_field(&value, "automation_id"),
+            incident_id: string_field(&value, "incident_id"),
+            event_id: string_field(&value, "event_id"),
+            queue_item_id: string_field(&value, "queue_item_id"),
+            workflow_ref: workflow_ref_string(&value),
+        });
+    }
+    Ok(decisions)
+}
+
+fn load_queue_items(repo_root: &Path, runtime_dir: &Path) -> Result<Vec<QueueItemRecord>> {
+    let queue_dir = runtime_dir.join("queue");
+    if !queue_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut items = Vec::new();
+    for lane in ["pending", "claimed", "retry", "dead-letter"] {
+        let lane_dir = queue_dir.join(lane);
+        if !lane_dir.is_dir() {
+            continue;
+        }
+        for entry in fs::read_dir(&lane_dir).map_err(|e| io_error("read queue lane dir", &lane_dir, e))? {
+            let entry = entry.map_err(|e| io_error("read queue lane entry", &lane_dir, e))?;
+            let path = entry.path();
+            if !path.is_file() || path.extension().and_then(|v| v.to_str()) != Some("json") {
+                continue;
+            }
+            let value = read_json_value(&path)?;
+            items.push(QueueItemRecord {
+                queue_item_id: required_string(&value, "queue_item_id", &path)?,
+                path: rel_path(repo_root, &path),
+                lane: lane.to_string(),
+                status: string_field(&value, "status").unwrap_or_else(|| lane.to_string()),
+                summary: string_field(&value, "summary"),
+                target_automation_id: string_field(&value, "target_automation_id"),
+                event_id: string_field(&value, "event_id"),
+                watcher_id: string_field(&value, "watcher_id"),
+                payload_ref: string_field(&value, "payload_ref"),
+                enqueued_at: string_field(&value, "enqueued_at"),
+                claim_deadline: string_field(&value, "claim_deadline"),
+            });
+        }
+    }
+    Ok(items)
+}
+
+fn load_queue_receipts(_repo_root: &Path, runtime_dir: &Path) -> Result<Vec<QueueReceiptRecord>> {
+    let receipts_dir = runtime_dir.join("queue").join("receipts");
+    if !receipts_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut items = Vec::new();
+    for entry in fs::read_dir(&receipts_dir).map_err(|e| io_error("read queue receipts dir", &receipts_dir, e))? {
+        let entry = entry.map_err(|e| io_error("read queue receipt entry", &receipts_dir, e))?;
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|v| v.to_str()) != Some("json") {
+            continue;
+        }
+        let value = read_json_value(&path)?;
+        items.push(QueueReceiptRecord {
+            handled_at: string_field(&value, "handled_at"),
+        });
+    }
+    Ok(items)
+}
+
+fn load_watchers(repo_root: &Path, runtime_dir: &Path) -> Result<Vec<WatcherRecord>> {
+    let watchers_dir = runtime_dir.join("watchers");
+    if !watchers_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut items = Vec::new();
+    for entry in fs::read_dir(&watchers_dir).map_err(|e| io_error("read watchers dir", &watchers_dir, e))? {
+        let entry = entry.map_err(|e| io_error("read watchers dir entry", &watchers_dir, e))?;
+        let path = entry.path();
+        let rel_name = path.file_name().and_then(|v| v.to_str()).unwrap_or_default();
+        if !path.is_dir() || rel_name.starts_with('_') {
+            continue;
+        }
+        let watcher_yml = path.join("watcher.yml");
+        if !watcher_yml.is_file() {
+            continue;
+        }
+        let watcher = read_yaml_value(&watcher_yml)?;
+        let health = read_optional_json_value(&path.join("state/health.json"))?;
+        let suppressions = read_optional_json_value(&path.join("state/suppressions.json"))?;
+        items.push(WatcherRecord {
+            watcher_id: required_string(&watcher, "watcher_id", &watcher_yml)?,
+            path: rel_path(repo_root, &watcher_yml),
+            title: string_field(&watcher, "title").unwrap_or_else(|| rel_name.to_string()),
+            owner: string_field(&watcher, "owner").unwrap_or_else(|| "unknown".to_string()),
+            status: string_field(&watcher, "status").unwrap_or_else(|| "unknown".to_string()),
+            health_status: health
+                .as_ref()
+                .and_then(|value| string_field(value, "status"))
+                .unwrap_or_else(|| "unknown".to_string()),
+            health_reason: health
+                .as_ref()
+                .and_then(|value| string_field(value, "reason").or_else(|| string_field(value, "error_reason"))),
+            last_evaluated_at: health.as_ref().and_then(|value| string_field(value, "checked_at")),
+            suppressed_count: suppressions
+                .as_ref()
+                .and_then(|value| value.get("suppressed").and_then(|v| v.as_array()).map(|v| v.len()))
+                .unwrap_or(0),
+        });
+    }
+    Ok(items)
+}
+
+fn load_automations(repo_root: &Path, runtime_dir: &Path) -> Result<Vec<AutomationRecord>> {
+    let automations_dir = runtime_dir.join("automations");
+    if !automations_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut items = Vec::new();
+    for entry in fs::read_dir(&automations_dir).map_err(|e| io_error("read automations dir", &automations_dir, e))? {
+        let entry = entry.map_err(|e| io_error("read automations dir entry", &automations_dir, e))?;
+        let path = entry.path();
+        let rel_name = path.file_name().and_then(|v| v.to_str()).unwrap_or_default();
+        if !path.is_dir() || rel_name.starts_with('_') {
+            continue;
+        }
+        let automation_yml = path.join("automation.yml");
+        if !automation_yml.is_file() {
+            continue;
+        }
+        let automation = read_yaml_value(&automation_yml)?;
+        let counters = read_optional_json_value(&path.join("state/counters.json"))?;
+        let state_status = read_optional_json_value(&path.join("state/status.json"))?;
+        items.push(AutomationRecord {
+            automation_id: required_string(&automation, "automation_id", &automation_yml)?,
+            path: rel_path(repo_root, &automation_yml),
+            title: string_field(&automation, "title").unwrap_or_else(|| rel_name.to_string()),
+            owner: string_field(&automation, "owner").unwrap_or_else(|| "unknown".to_string()),
+            status: string_field(&automation, "status").unwrap_or_else(|| "unknown".to_string()),
+            workflow_ref: workflow_ref_string(&automation),
+            state_status: state_status.as_ref().and_then(|value| string_field(value, "status")),
+            state_reason: state_status
+                .as_ref()
+                .and_then(|value| string_field(value, "reason").or_else(|| string_field(value, "error_reason"))),
+            counters_blocked: counters
+                .as_ref()
+                .and_then(|value| usize_field(value, "blocked"))
+                .unwrap_or(0),
+        });
+    }
+    Ok(items)
+}
+
+fn load_missions(repo_root: &Path, runtime_dir: &Path) -> Result<Vec<MissionRecord>> {
+    let missions_dir = runtime_dir.join("missions");
+    if !missions_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut items = Vec::new();
+    for entry in fs::read_dir(&missions_dir).map_err(|e| io_error("read missions dir", &missions_dir, e))? {
+        let entry = entry.map_err(|e| io_error("read missions dir entry", &missions_dir, e))?;
+        let path = entry.path();
+        let rel_name = path.file_name().and_then(|v| v.to_str()).unwrap_or_default();
+        if !path.is_dir() || rel_name.starts_with('_') || rel_name == ".archive" {
+            continue;
+        }
+        let mission_yml = path.join("mission.yml");
+        if !mission_yml.is_file() {
+            continue;
+        }
+        let mission = read_yaml_value(&mission_yml)?;
+        let tasks = read_optional_json_value(&path.join("tasks.json"))?;
+        let (blocked_task_count, outstanding_task_count) = count_tasks(tasks.as_ref());
+        items.push(MissionRecord {
+            mission_id: required_string(&mission, "mission_id", &mission_yml)?,
+            path: rel_path(repo_root, &mission_yml),
+            title: string_field(&mission, "title").unwrap_or_else(|| rel_name.to_string()),
+            status: string_field(&mission, "status").unwrap_or_else(|| "unknown".to_string()),
+            owner: string_field(&mission, "owner").unwrap_or_else(|| "unknown".to_string()),
+            active_run_ids: string_array_field(&mission, "active_run_ids"),
+            blocked_task_count,
+            outstanding_task_count,
+        });
+    }
+    Ok(items)
+}
+
+fn load_incidents(repo_root: &Path, runtime_dir: &Path) -> Result<Vec<IncidentRecord>> {
+    let incidents_dir = runtime_dir.join("incidents");
+    if !incidents_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut items = Vec::new();
+    for entry in fs::read_dir(&incidents_dir).map_err(|e| io_error("read incidents dir", &incidents_dir, e))? {
+        let entry = entry.map_err(|e| io_error("read incidents dir entry", &incidents_dir, e))?;
+        let path = entry.path();
+        let rel_name = path.file_name().and_then(|v| v.to_str()).unwrap_or_default();
+        if !path.is_dir() || rel_name.starts_with('_') {
+            continue;
+        }
+        let incident_yml = path.join("incident.yml");
+        if !incident_yml.is_file() {
+            continue;
+        }
+        let incident = read_yaml_value(&incident_yml)?;
+        let timeline_path = path.join("timeline.md");
+        items.push(IncidentRecord {
+            incident_id: required_string(&incident, "incident_id", &incident_yml)?,
+            path: rel_path(repo_root, &incident_yml),
+            title: string_field(&incident, "title").unwrap_or_else(|| rel_name.to_string()),
+            severity: string_field(&incident, "severity").unwrap_or_else(|| "unknown".to_string()),
+            status: string_field(&incident, "status").unwrap_or_else(|| "unknown".to_string()),
+            owner: string_field(&incident, "owner").unwrap_or_else(|| "unknown".to_string()),
+            summary: string_field(&incident, "summary"),
+            linked_run_ids: string_array_field(&incident, "run_ids"),
+            last_timeline_update_at: parse_last_timeline_timestamp(&timeline_path).ok().flatten(),
+        });
+    }
+    Ok(items)
+}
+
+fn compute_incident_closure_readiness(repo_root: &Path, incident: &IncidentRecord) -> Result<ClosureReadiness> {
+    let incident_path = repo_root.join(&incident.path);
+    let incident_dir = incident_path.parent().unwrap_or_else(|| Path::new("."));
+    let closure_path = incident_dir.join("closure.md");
+    let closure_text = if closure_path.is_file() {
+        Some(
+            fs::read_to_string(&closure_path)
+                .map_err(|e| io_error("read incident closure file", &closure_path, e))?,
+        )
+    } else {
+        None
+    };
+
+    let mut blockers = Vec::new();
+    if incident.linked_run_ids.is_empty() {
+        blockers.push("missing linked runs".to_string());
+    }
+    let Some(closure_text) = closure_text else {
+        blockers.push("missing closure.md".to_string());
+        return Ok(ClosureReadiness {
+            incident_id: incident.incident_id.clone(),
+            title: incident.title.clone(),
+            severity: incident.severity.clone(),
+            status: incident.status.clone(),
+            owner: incident.owner.clone(),
+            linked_run_ids: incident.linked_run_ids.clone(),
+            ready: false,
+            blockers,
+        });
+    };
+
+    if !closure_text.contains("Approval:") {
+        blockers.push("missing approval reference".to_string());
+    }
+    if !closure_text.contains("Remediation Ref:") && !closure_text.contains("Waiver Ref:") {
+        blockers.push("missing remediation evidence or waiver".to_string());
+    }
+    if extract_closure_summary(&closure_text).is_none() {
+        blockers.push("missing closure summary".to_string());
+    }
+    if incident.status == "closed" {
+        if !closure_text.contains("Closed By:") {
+            blockers.push("missing closed_by evidence".to_string());
+        }
+        if !closure_text.contains("Closed At:") {
+            blockers.push("missing closed_at evidence".to_string());
+        }
+    } else {
+        blockers.push(format!("incident status is `{}`", incident.status));
+    }
+
+    Ok(ClosureReadiness {
+        incident_id: incident.incident_id.clone(),
+        title: incident.title.clone(),
+        severity: incident.severity.clone(),
+        status: incident.status.clone(),
+        owner: incident.owner.clone(),
+        linked_run_ids: incident.linked_run_ids.clone(),
+        ready: blockers.is_empty(),
+        blockers,
+    })
+}
+
+fn extract_closure_summary(text: &str) -> Option<String> {
+    let mut lines = Vec::new();
+    let mut in_summary = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("# Incident Closure") {
+            in_summary = true;
+            continue;
+        }
+        if trimmed.starts_with("## Remediation Evidence") {
+            break;
+        }
+        if !in_summary || trimmed.is_empty() || trimmed.starts_with("- Closed") || trimmed.starts_with("- Approval") {
+            continue;
+        }
+        lines.push(trimmed.to_string());
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join(" "))
+    }
+}
+
+fn incident_contains_event(item: &IncidentRecord, event_id: &str, repo_root: &Path) -> bool {
+    let incident_file = repo_root.join(&item.path);
+    match read_yaml_value(&incident_file) {
+        Ok(value) => string_array_field(&value, "event_ids")
+            .iter()
+            .any(|value| value == event_id),
+        Err(_) => false,
+    }
+}
+
+fn incident_contains_mission(item: &IncidentRecord, mission_id: &str, repo_root: &Path) -> bool {
+    let incident_file = repo_root.join(&item.path);
+    match read_yaml_value(&incident_file) {
+        Ok(value) => string_array_field(&value, "mission_ids")
+            .iter()
+            .any(|value| value == mission_id),
+        Err(_) => false,
+    }
+}
+
+fn read_event_timestamp(repo_root: &Path, payload_ref: &str) -> Result<Option<String>> {
+    let path = resolve_repo_relative(repo_root, payload_ref);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let value = read_json_value(&path)?;
+    Ok(string_field(&value, "emitted_at"))
+}
+
+fn count_tasks(tasks: Option<&Value>) -> (usize, usize) {
+    let mut blocked = 0;
+    let mut outstanding = 0;
+    let Some(tasks) = tasks else {
+        return (0, 0);
+    };
+    let Some(entries) = tasks.get("tasks").and_then(|value| value.as_array()) else {
+        return (0, 0);
+    };
+    for item in entries {
+        let status = item
+            .get("status")
+            .and_then(|value| value.as_str())
+            .unwrap_or("open");
+        if status.eq_ignore_ascii_case("blocked") {
+            blocked += 1;
+            outstanding += 1;
+            continue;
+        }
+        if !matches!(status.to_ascii_lowercase().as_str(), "done" | "completed" | "cancelled") {
+            outstanding += 1;
+        }
+    }
+    (blocked, outstanding)
+}
+
+fn to_json_value<T: Serialize>(value: &T) -> Result<Value> {
+    serde_json::to_value(value).map_err(|e| {
+        KernelError::new(
+            ErrorCode::Internal,
+            format!("failed to serialize orchestration inspection value: {e}"),
+        )
+    })
+}
+
+fn rel_path(repo_root: &Path, path: &Path) -> String {
+    path.strip_prefix(repo_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn resolve_repo_relative(repo_root: &Path, raw: &str) -> PathBuf {
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        repo_root.join(path)
+    }
+}
+
+fn read_yaml_value(path: &Path) -> Result<Value> {
+    let text = fs::read_to_string(path).map_err(|e| io_error("read YAML file", path, e))?;
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&text).map_err(|e| {
+        KernelError::new(
+            ErrorCode::Internal,
+            format!("failed to parse YAML {}: {e}", path.display()),
+        )
+    })?;
+    serde_json::to_value(yaml).map_err(|e| {
+        KernelError::new(
+            ErrorCode::Internal,
+            format!("failed to convert YAML {} to JSON value: {e}", path.display()),
+        )
+    })
+}
+
+fn read_optional_json_value(path: &Path) -> Result<Option<Value>> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    read_json_value(path).map(Some)
+}
+
+fn read_json_value(path: &Path) -> Result<Value> {
+    let text = fs::read_to_string(path).map_err(|e| io_error("read JSON file", path, e))?;
+    serde_json::from_str(&text).map_err(|e| {
+        KernelError::new(
+            ErrorCode::Internal,
+            format!("failed to parse JSON {}: {e}", path.display()),
+        )
+    })
+}
+
+fn required_string(value: &Value, key: &str, path: &Path) -> Result<String> {
+    string_field(value, key).ok_or_else(|| {
+        KernelError::new(
+            ErrorCode::Internal,
+            format!("{} missing required string field '{}'", path.display(), key),
+        )
+    })
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(|item| item.as_str()).map(ToString::to_string)
+}
+
+fn workflow_ref_string(value: &Value) -> Option<String> {
+    let workflow_group = value
+        .get("workflow_ref")
+        .and_then(|item| item.get("workflow_group"))
+        .and_then(|item| item.as_str())?;
+    let workflow_id = value
+        .get("workflow_ref")
+        .and_then(|item| item.get("workflow_id"))
+        .and_then(|item| item.as_str())?;
+    Some(format!("{workflow_group}/{workflow_id}"))
+}
+
+fn usize_field(value: &Value, key: &str) -> Option<usize> {
+    value.get(key).and_then(|item| item.as_u64()).map(|item| item as usize)
+}
+
+fn string_array_field(value: &Value, key: &str) -> Vec<String> {
+    value.get(key)
+        .and_then(|item| item.as_array())
+        .map(|items| {
+            items.iter()
+                .filter_map(|item| item.as_str().map(ToString::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_last_timeline_timestamp(path: &Path) -> Result<Option<String>> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let text = fs::read_to_string(path).map_err(|e| io_error("read timeline file", path, e))?;
+    for line in text.lines().rev() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("- ") {
+            if let Some((timestamp, _)) = rest.split_once(':') {
+                if timestamp.contains('T') {
+                    return Ok(Some(timestamp.to_string()));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn parse_timestamp(raw: &str) -> Option<OffsetDateTime> {
+    OffsetDateTime::parse(raw, &Rfc3339).ok()
+}
+
+fn now_utc() -> Result<String> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|e| KernelError::new(ErrorCode::Internal, format!("failed to format current timestamp: {e}")))
+}
+
+fn io_error(action: &str, path: &Path, error: std::io::Error) -> KernelError {
+    KernelError::new(
+        ErrorCode::Internal,
+        format!("{action} {}: {error}", path.display()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!("harmony-orch-core-{label}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("create temp root");
+        root
+    }
+
+    fn seed_base(root: &Path) {
+        for rel in [
+            ".harmony/orchestration/runtime/runs/by-surface/workflows",
+            ".harmony/orchestration/runtime/runs/by-surface/missions",
+            ".harmony/orchestration/runtime/runs/by-surface/automations",
+            ".harmony/orchestration/runtime/runs/by-surface/incidents",
+            ".harmony/orchestration/runtime/queue/pending",
+            ".harmony/orchestration/runtime/queue/claimed",
+            ".harmony/orchestration/runtime/queue/retry",
+            ".harmony/orchestration/runtime/queue/dead-letter",
+            ".harmony/orchestration/runtime/queue/receipts",
+            ".harmony/orchestration/runtime/watchers/example/state",
+            ".harmony/orchestration/runtime/automations/example/state",
+            ".harmony/orchestration/runtime/missions/example/context",
+            ".harmony/orchestration/runtime/incidents/inc-001",
+            ".harmony/orchestration/runtime/workflows/example/sample",
+            ".harmony/continuity/decisions/dec-001",
+            ".harmony/continuity/runs/run-001",
+            ".harmony/orchestration/governance",
+        ] {
+            fs::create_dir_all(root.join(rel)).expect("create fixture dirs");
+        }
+        fs::write(
+            root.join(".harmony/orchestration/runtime/queue/registry.yml"),
+            "schema_version: orchestration-queue-registry-v1\n",
+        )
+        .expect("write queue registry");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/runs/index.yml"),
+            "schema_version: orchestration-runs-index-v1\nruns: []\n",
+        )
+        .expect("write run index");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/incidents/index.yml"),
+            "schema_version: orchestration-incidents-index-v1\nincidents: []\n",
+        )
+        .expect("write incident index");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/missions/registry.yml"),
+            "schema_version: '1.0'\nactive: []\narchived: []\n",
+        )
+        .expect("write mission registry");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/watchers/example/watcher.yml"),
+            "watcher_id: example\ntitle: Example Watcher\nowner: '@architect'\nstatus: active\n",
+        )
+        .expect("write watcher");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/watchers/example/state/health.json"),
+            "{\n  \"status\": \"healthy\",\n  \"checked_at\": \"2026-03-11T10:00:00Z\"\n}\n",
+        )
+        .expect("write health");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/watchers/example/state/suppressions.json"),
+            "{\n  \"suppressed\": [\"evt-old\"]\n}\n",
+        )
+        .expect("write suppressions");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/automations/example/automation.yml"),
+            "automation_id: example\ntitle: Example Automation\nowner: '@architect'\nstatus: active\nworkflow_ref:\n  workflow_group: example\n  workflow_id: sample\n",
+        )
+        .expect("write automation");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/automations/example/state/counters.json"),
+            "{\n  \"blocked\": 2\n}\n",
+        )
+        .expect("write counters");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/automations/example/state/status.json"),
+            "{\n  \"status\": \"active\"\n}\n",
+        )
+        .expect("write automation status");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/missions/example/mission.yml"),
+            "schema_version: mission-object-v1\nmission_id: example\ntitle: Example Mission\nsummary: Example mission.\nstatus: active\nowner: '@architect'\ncreated_at: '2026-03-10T00:00:00Z'\nactive_run_ids:\n  - run-001\n",
+        )
+        .expect("write mission");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/missions/example/tasks.json"),
+            "{\n  \"tasks\": [\n    {\"id\": \"t1\", \"status\": \"blocked\"},\n    {\"id\": \"t2\", \"status\": \"open\"},\n    {\"id\": \"t3\", \"status\": \"done\"}\n  ]\n}\n",
+        )
+        .expect("write tasks");
+        fs::write(
+            root.join(".harmony/continuity/decisions/dec-001/decision.json"),
+            "{\n  \"decision_id\": \"dec-001\",\n  \"outcome\": \"allow\",\n  \"surface\": \"automations\",\n  \"action\": \"launch\",\n  \"actor\": \"example\",\n  \"summary\": \"Allowed.\",\n  \"run_id\": \"run-001\",\n  \"automation_id\": \"example\",\n  \"event_id\": \"evt-001\",\n  \"queue_item_id\": \"q-001\",\n  \"workflow_ref\": {\"workflow_group\": \"example\", \"workflow_id\": \"sample\"}\n}\n",
+        )
+        .expect("write decision");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/runs/run-001.yml"),
+            "run_id: run-001\nstatus: running\nstarted_at: '2026-03-11T10:10:00Z'\ndecision_id: dec-001\ncontinuity_run_path: '.harmony/continuity/runs/run-001/'\nsummary: Example run\nexecutor_id: exec-1\nexecutor_acknowledged_at: '2026-03-11T10:10:01Z'\nlast_heartbeat_at: '2026-03-11T10:15:00Z'\nlease_expires_at: '2099-03-11T10:20:00Z'\nrecovery_status: healthy\nworkflow_ref:\n  workflow_group: example\n  workflow_id: sample\nautomation_id: example\nmission_id: example\nincident_id: inc-001\nqueue_item_id: q-001\nevent_id: evt-001\n",
+        )
+        .expect("write run");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/queue/pending/q-001.json"),
+            "{\n  \"queue_item_id\": \"q-001\",\n  \"target_automation_id\": \"example\",\n  \"status\": \"pending\",\n  \"summary\": \"Queued.\",\n  \"event_id\": \"evt-001\",\n  \"watcher_id\": \"example\",\n  \"payload_ref\": \"/tmp/harmony-orch-event.json\",\n  \"enqueued_at\": \"2026-03-11T10:05:00Z\",\n  \"available_at\": \"2026-03-11T10:05:00Z\"\n}\n",
+        )
+        .expect("write queue item");
+        fs::write(
+            Path::new("/tmp/harmony-orch-event.json"),
+            "{\n  \"event_id\": \"evt-001\",\n  \"emitted_at\": \"2026-03-11T10:04:00Z\"\n}\n",
+        )
+        .expect("write event");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/queue/receipts/q-001-ack-20260311T101600Z.json"),
+            "{\n  \"queue_item_id\": \"q-001\",\n  \"handled_at\": \"2026-03-11T10:16:00Z\"\n}\n",
+        )
+        .expect("write receipt");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/incidents/inc-001/incident.yml"),
+            "incident_id: inc-001\ntitle: Example Incident\nseverity: sev2\nstatus: closed\nowner: '@architect'\nsummary: Incident summary\nrun_ids:\n  - run-001\n",
+        )
+        .expect("write incident");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/incidents/inc-001/timeline.md"),
+            "# Incident Timeline: inc-001\n\n- 2026-03-11T10:20:00Z: incident updated\n",
+        )
+        .expect("write timeline");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/incidents/inc-001/closure.md"),
+            "# Incident Closure: inc-001\n\n- Closed At: `2026-03-11T10:30:00Z`\n- Closed By: `@architect`\n- Approval: `appr-001`\n\nClosed with evidence.\n\n## Remediation Evidence\n\n- Remediation Ref: `run:run-001`\n",
+        )
+        .expect("write closure");
+        fs::write(
+            root.join(".harmony/orchestration/runtime/workflows/example/sample/workflow.yml"),
+            "schema_version: workflow-contract-v1\nname: sample\ndescription: Example workflow.\nversion: 1.0.0\nentry_mode: human\nexecution_profile: core\nstages: []\ndone_gate:\n  checks: []\n",
+        )
+        .expect("write workflow");
+    }
+
+    #[test]
+    fn lookup_resolves_run_and_event_lineage() {
+        let root = temp_root("lookup");
+        seed_base(&root);
+        let inspector = OrchestrationInspector::from_repo_root(&root).expect("load inspector");
+
+        let run_lookup = inspector
+            .lookup(LookupQuery::RunId("run-001".to_string()))
+            .expect("run lookup should succeed");
+        assert!(run_lookup.artifacts.iter().any(|item| item.kind == "decision" && item.id == "dec-001"));
+        assert!(run_lookup.artifacts.iter().any(|item| item.kind == "queue_item" && item.id == "q-001"));
+        assert!(run_lookup.artifacts.iter().any(|item| item.kind == "continuity_run" && item.id == "run-001"));
+
+        let event_lookup = inspector
+            .lookup(LookupQuery::EventId("evt-001".to_string()))
+            .expect("event lookup should succeed");
+        assert!(event_lookup.artifacts.iter().any(|item| item.kind == "run" && item.id == "run-001"));
+        assert!(event_lookup.artifacts.iter().any(|item| item.kind == "queue_item" && item.id == "q-001"));
+
+        let _ = fs::remove_file("/tmp/harmony-orch-event.json");
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn snapshot_reports_surface_health() {
+        let root = temp_root("snapshot");
+        seed_base(&root);
+        let inspector = OrchestrationInspector::from_repo_root(&root).expect("load inspector");
+        let snapshot = inspector.snapshot().expect("snapshot should succeed");
+
+        assert_eq!(snapshot.overview.queue_pending_count, 1);
+        assert_eq!(snapshot.overview.running_run_count, 1);
+        assert_eq!(snapshot.watchers[0].suppressed_count, 1);
+        assert_eq!(snapshot.automations[0].suppression_count, 2);
+        assert_eq!(snapshot.missions[0].blocked_task_count, 1);
+        assert_eq!(snapshot.incidents[0].closure_ready, true);
+
+        let _ = fs::remove_file("/tmp/harmony-orch-event.json");
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn incident_closure_readiness_reports_missing_evidence() {
+        let root = temp_root("closure");
+        seed_base(&root);
+        fs::write(
+            root.join(".harmony/orchestration/runtime/incidents/inc-001/incident.yml"),
+            "incident_id: inc-001\ntitle: Example Incident\nseverity: sev2\nstatus: open\nowner: '@architect'\nsummary: Incident summary\n",
+        )
+        .expect("rewrite incident");
+        fs::remove_file(root.join(".harmony/orchestration/runtime/incidents/inc-001/closure.md"))
+            .expect("remove closure");
+        let inspector = OrchestrationInspector::from_repo_root(&root).expect("load inspector");
+        let readiness = inspector
+            .incident_closure_readiness("inc-001")
+            .expect("closure readiness should succeed");
+
+        assert!(!readiness.ready);
+        assert!(readiness.blockers.iter().any(|item| item == "missing linked runs"));
+        assert!(readiness.blockers.iter().any(|item| item == "missing closure.md"));
+
+        let _ = fs::remove_file("/tmp/harmony-orch-event.json");
+        fs::remove_dir_all(root).ok();
+    }
+}

--- a/.harmony/engine/runtime/crates/core/src/root.rs
+++ b/.harmony/engine/runtime/crates/core/src/root.rs
@@ -7,6 +7,10 @@ pub struct RootResolver;
 impl RootResolver {
     /// Resolve from an explicit starting directory.
     pub fn resolve_from(start: &Path) -> Result<PathBuf> {
+        if let Some(override_path) = override_harmony_dir()? {
+            return Ok(override_path);
+        }
+
         let mut cur = start
             .canonicalize()
             .map_err(|e| KernelError::new(ErrorCode::Internal, format!("failed to canonicalize cwd: {e}")))?;
@@ -30,8 +34,51 @@ impl RootResolver {
 
     /// Resolve from the current working directory.
     pub fn resolve() -> Result<PathBuf> {
+        if let Some(override_path) = override_harmony_dir()? {
+            return Ok(override_path);
+        }
+
         let cwd = std::env::current_dir()
             .map_err(|e| KernelError::new(ErrorCode::Internal, format!("failed to read cwd: {e}")))?;
         Self::resolve_from(&cwd)
     }
+}
+
+fn override_harmony_dir() -> Result<Option<PathBuf>> {
+    if let Some(harmony_dir) = std::env::var_os("HARMONY_DIR_OVERRIDE") {
+        let path = PathBuf::from(harmony_dir);
+        let canonical = path.canonicalize().map_err(|e| {
+            KernelError::new(
+                ErrorCode::Internal,
+                format!("failed to canonicalize HARMONY_DIR_OVERRIDE {}: {e}", path.display()),
+            )
+        })?;
+        if !canonical.is_dir() {
+            return Err(KernelError::new(
+                ErrorCode::Internal,
+                format!("HARMONY_DIR_OVERRIDE is not a directory: {}", canonical.display()),
+            ));
+        }
+        return Ok(Some(canonical));
+    }
+
+    if let Some(root_dir) = std::env::var_os("HARMONY_ROOT_DIR") {
+        let root = PathBuf::from(root_dir);
+        let harmony_dir = root.join(".harmony");
+        let canonical = harmony_dir.canonicalize().map_err(|e| {
+            KernelError::new(
+                ErrorCode::Internal,
+                format!("failed to canonicalize HARMONY_ROOT_DIR/.harmony {}: {e}", harmony_dir.display()),
+            )
+        })?;
+        if !canonical.is_dir() {
+            return Err(KernelError::new(
+                ErrorCode::Internal,
+                format!("HARMONY_ROOT_DIR does not contain .harmony/: {}", canonical.display()),
+            ));
+        }
+        return Ok(Some(canonical));
+    }
+
+    Ok(None)
 }

--- a/.harmony/engine/runtime/crates/kernel/src/main.rs
+++ b/.harmony/engine/runtime/crates/kernel/src/main.rs
@@ -1,14 +1,16 @@
 mod context;
+mod orchestration;
 mod pipeline;
 mod scaffold;
 mod stdio;
 mod workflow;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use harmony_core::errors::{ErrorCode, KernelError};
 use harmony_core::tiers::validate_runtime_discovery_tiers;
 use harmony_core::trace::TraceWriter;
 use harmony_wasm_host::policy::GrantSet;
+use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 use std::sync::Arc;
 
@@ -69,6 +71,12 @@ enum Command {
         #[command(subcommand)]
         cmd: WorkflowCmd,
     },
+
+    /// Read-only orchestration operator inspection commands.
+    Orchestration {
+        #[command(subcommand)]
+        cmd: OrchestrationCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -125,6 +133,124 @@ enum WorkflowCmd {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum OrchestrationSurfaceArg {
+    Watchers,
+    Queue,
+    Automations,
+    Runs,
+    Missions,
+    Incidents,
+    All,
+}
+
+impl From<OrchestrationSurfaceArg> for harmony_core::orchestration::SummarySurface {
+    fn from(value: OrchestrationSurfaceArg) -> Self {
+        match value {
+            OrchestrationSurfaceArg::Watchers => Self::Watchers,
+            OrchestrationSurfaceArg::Queue => Self::Queue,
+            OrchestrationSurfaceArg::Automations => Self::Automations,
+            OrchestrationSurfaceArg::Runs => Self::Runs,
+            OrchestrationSurfaceArg::Missions => Self::Missions,
+            OrchestrationSurfaceArg::Incidents => Self::Incidents,
+            OrchestrationSurfaceArg::All => Self::All,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Args)]
+#[group(required = true, multiple = false)]
+struct OrchestrationLookupArgs {
+    #[arg(long = "decision-id")]
+    decision_id: Option<String>,
+    #[arg(long = "run-id")]
+    run_id: Option<String>,
+    #[arg(long = "incident-id")]
+    incident_id: Option<String>,
+    #[arg(long = "queue-item-id")]
+    queue_item_id: Option<String>,
+    #[arg(long = "event-id")]
+    event_id: Option<String>,
+    #[arg(long = "automation-id")]
+    automation_id: Option<String>,
+    #[arg(long = "watcher-id")]
+    watcher_id: Option<String>,
+    #[arg(long = "mission-id")]
+    mission_id: Option<String>,
+}
+
+impl TryFrom<OrchestrationLookupArgs> for harmony_core::orchestration::LookupQuery {
+    type Error = anyhow::Error;
+
+    fn try_from(value: OrchestrationLookupArgs) -> Result<Self, Self::Error> {
+        if let Some(id) = value.decision_id {
+            return Ok(Self::DecisionId(id));
+        }
+        if let Some(id) = value.run_id {
+            return Ok(Self::RunId(id));
+        }
+        if let Some(id) = value.incident_id {
+            return Ok(Self::IncidentId(id));
+        }
+        if let Some(id) = value.queue_item_id {
+            return Ok(Self::QueueItemId(id));
+        }
+        if let Some(id) = value.event_id {
+            return Ok(Self::EventId(id));
+        }
+        if let Some(id) = value.automation_id {
+            return Ok(Self::AutomationId(id));
+        }
+        if let Some(id) = value.watcher_id {
+            return Ok(Self::WatcherId(id));
+        }
+        if let Some(id) = value.mission_id {
+            return Ok(Self::MissionId(id));
+        }
+        anyhow::bail!("exactly one orchestration lookup id is required");
+    }
+}
+
+#[derive(Subcommand)]
+enum OrchestrationIncidentCmd {
+    /// Evaluate incident closure readiness.
+    ClosureReadiness {
+        #[arg(long = "incident-id")]
+        incident_id: String,
+        #[arg(long, value_enum, default_value_t = orchestration::OutputFormat::Json)]
+        format: orchestration::OutputFormat,
+        #[arg(long = "output-report")]
+        output_report: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum OrchestrationCmd {
+    /// Resolve forward and reverse orchestration lineage by canonical id.
+    Lookup {
+        #[command(flatten)]
+        query: OrchestrationLookupArgs,
+        #[arg(long, value_enum, default_value_t = orchestration::OutputFormat::Json)]
+        format: orchestration::OutputFormat,
+        #[arg(long = "output-report")]
+        output_report: Option<PathBuf>,
+    },
+    /// Summarize orchestration surface health.
+    Summary {
+        #[arg(long, value_enum)]
+        surface: OrchestrationSurfaceArg,
+        #[arg(long, value_enum, default_value_t = orchestration::OutputFormat::Json)]
+        format: orchestration::OutputFormat,
+        #[arg(long = "output-report")]
+        output_report: Option<PathBuf>,
+    },
+    /// Incident-specific operator inspection commands.
+    Incident {
+        #[command(subcommand)]
+        cmd: OrchestrationIncidentCmd,
+    },
+}
+
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -137,6 +263,7 @@ fn main() -> anyhow::Result<()> {
         Command::Studio => cmd_studio(),
         Command::Service { cmd } => cmd_service(cmd),
         Command::Workflow { cmd } => cmd_workflow(cmd),
+        Command::Orchestration { cmd } => cmd_orchestration(cmd),
     }
 }
 
@@ -321,6 +448,49 @@ fn cmd_workflow(cmd: WorkflowCmd) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn cmd_orchestration(cmd: OrchestrationCmd) -> anyhow::Result<()> {
+    let harmony_dir = harmony_core::root::RootResolver::resolve()?;
+    let repo_root = harmony_dir
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!(".harmony has no repository root"))?
+        .to_path_buf();
+
+    match cmd {
+        OrchestrationCmd::Lookup {
+            query,
+            format,
+            output_report,
+        } => orchestration::write_lookup(
+            &harmony_dir,
+            query.try_into()?,
+            format,
+            output_report.as_deref().map(|path| resolve_output_path(&repo_root, path)),
+        ),
+        OrchestrationCmd::Summary {
+            surface,
+            format,
+            output_report,
+        } => orchestration::write_summary(
+            &harmony_dir,
+            surface.into(),
+            format,
+            output_report.as_deref().map(|path| resolve_output_path(&repo_root, path)),
+        ),
+        OrchestrationCmd::Incident { cmd } => match cmd {
+            OrchestrationIncidentCmd::ClosureReadiness {
+                incident_id,
+                format,
+                output_report,
+            } => orchestration::write_incident_closure_readiness(
+                &harmony_dir,
+                &incident_id,
+                format,
+                output_report.as_deref().map(|path| resolve_output_path(&repo_root, path)),
+            ),
+        },
+    }
+}
+
 fn parse_category_name(target: &str, name: Option<&str>) -> anyhow::Result<(String, String)> {
     if let Some((category, service)) = target.split_once('/') {
         if category.is_empty() || service.is_empty() {
@@ -358,9 +528,20 @@ fn parse_kv_overrides(
     Ok(out)
 }
 
+fn resolve_output_path(repo_root: &std::path::Path, raw: &std::path::Path) -> PathBuf {
+    if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        repo_root.join(raw)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Command, WorkflowCmd};
+    use super::{
+        Cli, Command, OrchestrationCmd, OrchestrationIncidentCmd, OrchestrationSurfaceArg,
+        WorkflowCmd,
+    };
     use crate::workflow::ExecutorKind;
     use clap::{CommandFactory, Parser};
 
@@ -459,5 +640,94 @@ mod tests {
             }
             _ => panic!("parsed command should be workflow validate"),
         }
+    }
+
+    #[test]
+    fn cli_parses_orchestration_lookup_subcommand() {
+        let cli = Cli::try_parse_from([
+            "harmony",
+            "orchestration",
+            "lookup",
+            "--run-id",
+            "run-001",
+            "--format",
+            "markdown",
+        ])
+        .expect("orchestration lookup should parse");
+
+        match cli.cmd {
+            Command::Orchestration {
+                cmd:
+                    OrchestrationCmd::Lookup {
+                        query,
+                        format,
+                        ..
+                    },
+            } => {
+                assert_eq!(query.run_id.as_deref(), Some("run-001"));
+                assert_eq!(format, crate::orchestration::OutputFormat::Markdown);
+            }
+            _ => panic!("parsed command should be orchestration lookup"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_orchestration_summary_subcommand() {
+        let cli = Cli::try_parse_from([
+            "harmony",
+            "orchestration",
+            "summary",
+            "--surface",
+            "all",
+        ])
+        .expect("orchestration summary should parse");
+
+        match cli.cmd {
+            Command::Orchestration {
+                cmd: OrchestrationCmd::Summary { surface, .. },
+            } => assert_eq!(surface, OrchestrationSurfaceArg::All),
+            _ => panic!("parsed command should be orchestration summary"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_orchestration_incident_closure_subcommand() {
+        let cli = Cli::try_parse_from([
+            "harmony",
+            "orchestration",
+            "incident",
+            "closure-readiness",
+            "--incident-id",
+            "inc-001",
+        ])
+        .expect("incident closure-readiness should parse");
+
+        match cli.cmd {
+            Command::Orchestration {
+                cmd:
+                    OrchestrationCmd::Incident {
+                        cmd:
+                            OrchestrationIncidentCmd::ClosureReadiness { incident_id, .. },
+                    },
+            } => assert_eq!(incident_id, "inc-001"),
+            _ => panic!("parsed command should be incident closure-readiness"),
+        }
+    }
+
+    #[test]
+    fn cli_help_lists_orchestration_command() {
+        let mut cmd = Cli::command();
+        let mut help = Vec::new();
+        cmd.write_long_help(&mut help)
+            .expect("long help should render");
+        let help = String::from_utf8(help).expect("help should be valid utf-8");
+        assert!(
+            help.contains("orchestration"),
+            "help output should contain orchestration command"
+        );
+        assert!(
+            help.contains("Read-only orchestration operator inspection commands"),
+            "help output should include orchestration description"
+        );
     }
 }

--- a/.harmony/engine/runtime/crates/kernel/src/orchestration.rs
+++ b/.harmony/engine/runtime/crates/kernel/src/orchestration.rs
@@ -1,0 +1,200 @@
+use anyhow::{Context, Result};
+use harmony_core::orchestration::{
+    ClosureReadiness, LookupQuery, LookupResult, OrchestrationInspector, OpsSnapshot, SurfaceSummary,
+    SummarySurface,
+};
+use clap::ValueEnum;
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum OutputFormat {
+    Json,
+    Markdown,
+}
+
+pub fn write_lookup(
+    harmony_dir: &Path,
+    query: LookupQuery,
+    format: OutputFormat,
+    output_report: Option<PathBuf>,
+) -> Result<()> {
+    let inspector = OrchestrationInspector::from_harmony_dir(harmony_dir)?;
+    let lookup = inspector.lookup(query)?;
+    let markdown = render_lookup_markdown(&lookup);
+    emit_output(&lookup, &markdown, format, output_report)
+}
+
+pub fn write_summary(
+    harmony_dir: &Path,
+    surface: SummarySurface,
+    format: OutputFormat,
+    output_report: Option<PathBuf>,
+) -> Result<()> {
+    let inspector = OrchestrationInspector::from_harmony_dir(harmony_dir)?;
+    let summary = inspector.summary(surface)?;
+    let snapshot = inspector.snapshot()?;
+    let markdown = render_summary_markdown(&summary, &snapshot);
+    emit_output(&summary, &markdown, format, output_report)
+}
+
+pub fn write_incident_closure_readiness(
+    harmony_dir: &Path,
+    incident_id: &str,
+    format: OutputFormat,
+    output_report: Option<PathBuf>,
+) -> Result<()> {
+    let inspector = OrchestrationInspector::from_harmony_dir(harmony_dir)?;
+    let readiness = inspector.incident_closure_readiness(incident_id)?;
+    let markdown = render_closure_readiness_markdown(&readiness);
+    emit_output(&readiness, &markdown, format, output_report)
+}
+
+fn emit_output<T: Serialize>(
+    value: &T,
+    markdown: &str,
+    format: OutputFormat,
+    output_report: Option<PathBuf>,
+) -> Result<()> {
+    let rendered = match format {
+        OutputFormat::Json => serde_json::to_string_pretty(value)
+            .context("failed to serialize orchestration output as JSON")?,
+        OutputFormat::Markdown => markdown.to_string(),
+    };
+
+    if let Some(path) = output_report {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create report parent {}", parent.display()))?;
+        }
+        fs::write(&path, rendered.as_bytes())
+            .with_context(|| format!("failed to write report {}", path.display()))?;
+    }
+
+    println!("{rendered}");
+    Ok(())
+}
+
+fn render_lookup_markdown(result: &LookupResult) -> String {
+    let mut body = String::new();
+    body.push_str("# Orchestration Lookup\n\n");
+    body.push_str(&format!(
+        "- query_kind: `{}`\n- query_id: `{}`\n\n",
+        result.query_kind, result.query_id
+    ));
+    body.push_str("## Artifacts\n\n");
+    if result.artifacts.is_empty() {
+        body.push_str("- none\n");
+    } else {
+        for artifact in &result.artifacts {
+            body.push_str(&format!(
+                "- `{}` `{}` -> `{}`{}\n",
+                artifact.kind,
+                artifact.id,
+                artifact.path,
+                artifact
+                    .status
+                    .as_ref()
+                    .map(|value| format!(" (`{value}`)"))
+                    .unwrap_or_default()
+            ));
+            if let Some(summary) = &artifact.summary {
+                body.push_str(&format!("  summary: {}\n", summary));
+            }
+            for (key, value) in &artifact.details {
+                body.push_str(&format!("  {}: {}\n", key, value));
+            }
+        }
+    }
+    body.push_str("\n## Relations\n\n");
+    if result.relations.is_empty() {
+        body.push_str("- none\n");
+    } else {
+        for relation in &result.relations {
+            body.push_str(&format!(
+                "- `{}` -> `{}` ({})\n",
+                relation.from, relation.to, relation.relation
+            ));
+        }
+    }
+    body.push_str("\n## Notes\n\n");
+    if result.notes.is_empty() {
+        body.push_str("- none\n");
+    } else {
+        for note in &result.notes {
+            body.push_str(&format!("- {}\n", note));
+        }
+    }
+    body
+}
+
+fn render_summary_markdown(summary: &SurfaceSummary, snapshot: &OpsSnapshot) -> String {
+    let mut body = String::new();
+    body.push_str("# Orchestration Summary\n\n");
+    body.push_str(&format!(
+        "- generated_at: `{}`\n- surface: `{}`\n\n",
+        summary.generated_at, summary.surface
+    ));
+
+    if summary.surface == "all" {
+        body.push_str("## Overview\n\n");
+        body.push_str(&format!(
+            "- watchers: {} ({} unhealthy)\n- automations: {} ({} attention)\n- runs: {} ({} running)\n- incidents: {} ({} open, {} blocked for closure)\n- queue: pending={} claimed={} retry={} dead_letter={} expired_claims={}\n",
+            snapshot.overview.watcher_count,
+            snapshot.overview.watcher_unhealthy_count,
+            snapshot.overview.automation_count,
+            snapshot.overview.automation_attention_count,
+            snapshot.overview.run_count,
+            snapshot.overview.running_run_count,
+            snapshot.overview.incident_count,
+            snapshot.overview.open_incident_count,
+            snapshot.overview.incident_closure_blocked_count,
+            snapshot.overview.queue_pending_count,
+            snapshot.overview.queue_claimed_count,
+            snapshot.overview.queue_retry_count,
+            snapshot.overview.queue_dead_letter_count,
+            snapshot.overview.queue_expired_claim_count
+        ));
+        return body;
+    }
+
+    body.push_str("## Payload\n\n");
+    body.push_str("```json\n");
+    body.push_str(
+        &serde_json::to_string_pretty(&summary.payload)
+            .unwrap_or_else(|_| "{}".to_string()),
+    );
+    body.push_str("\n```\n");
+    body
+}
+
+fn render_closure_readiness_markdown(readiness: &ClosureReadiness) -> String {
+    let mut body = String::new();
+    body.push_str("# Incident Closure Readiness\n\n");
+    body.push_str(&format!(
+        "- incident_id: `{}`\n- severity: `{}`\n- status: `{}`\n- owner: `{}`\n- ready: `{}`\n\n",
+        readiness.incident_id,
+        readiness.severity,
+        readiness.status,
+        readiness.owner,
+        readiness.ready
+    ));
+    body.push_str("## Linked Runs\n\n");
+    if readiness.linked_run_ids.is_empty() {
+        body.push_str("- none\n");
+    } else {
+        for run_id in &readiness.linked_run_ids {
+            body.push_str(&format!("- `{}`\n", run_id));
+        }
+    }
+    body.push_str("\n## Blockers\n\n");
+    if readiness.blockers.is_empty() {
+        body.push_str("- none\n");
+    } else {
+        for blocker in &readiness.blockers {
+            body.push_str(&format!("- {}\n", blocker));
+        }
+    }
+    body
+}

--- a/.harmony/engine/runtime/crates/kernel/src/pipeline.rs
+++ b/.harmony/engine/runtime/crates/kernel/src/pipeline.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::Write;
@@ -30,6 +30,32 @@ pub struct RunPipelineResult {
     pub bundle_root: PathBuf,
     pub summary_report: PathBuf,
     pub final_verdict: String,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkflowBundleMetadata {
+    kind: String,
+    id: String,
+    workflow_id: String,
+    version: String,
+    entry_mode: String,
+    execution_profile: String,
+    executor: String,
+    prepare_only: bool,
+    started_at: String,
+    completed_at: String,
+    summary: String,
+    commands: String,
+    validation: String,
+    inventory: String,
+    reports_dir: String,
+    stage_inputs_dir: String,
+    stage_logs_dir: String,
+    final_verdict: String,
+    resolved_inputs: BTreeMap<String, String>,
+    stage_assets: BTreeMap<String, String>,
+    stage_reports: BTreeMap<String, String>,
+    target_root: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -287,6 +313,7 @@ fn run_generic_pipeline(
     fs::create_dir_all(&reports_root)?;
 
     let date = today_string()?;
+    let started_at = now_rfc3339()?;
     let slug = options
         .output_slug
         .clone()
@@ -301,17 +328,35 @@ fn run_generic_pipeline(
     fs::create_dir_all(&stage_logs_dir)?;
 
     let summary_report = bundle_root.join("summary.md");
+    let commands_report = bundle_root.join("commands.md");
+    let validation_report = bundle_root.join("validation.md");
+    let inventory_report = bundle_root.join("inventory.md");
 
     let input_map = resolve_inputs(&contract, &options.input_overrides)?;
+    let resolved_inputs = input_map
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<BTreeMap<_, _>>();
     let target_root = input_map
         .get("package_path")
         .or_else(|| input_map.get("subsystem"))
         .or_else(|| input_map.get("docs_root"))
         .map(|value| resolve_relative_to_repo(&repo_root, value))
         .transpose()?;
+    let target_root_rel = target_root
+        .as_ref()
+        .map(|path| path.strip_prefix(&repo_root).unwrap_or(path).display().to_string());
+
+    let final_verdict = if options.prepare_only {
+        "prepared-only".to_string()
+    } else if options.executor == ExecutorKind::Mock {
+        "mock-executed".to_string()
+    } else {
+        "manual-review-required".to_string()
+    };
 
     let mut summary = format!(
-        "# Workflow Run Summary\n\n- workflow_id: `{}`\n- version: `{}`\n- entry_mode: `{}`\n- description: `{}`\n- execution_profile: `{}`\n- canonical_path: `{}`\n- bundle_root: `{}`\n- prepare_only: `{}`\n",
+        "# Workflow Run Summary\n\n- workflow_id: `{}`\n- version: `{}`\n- entry_mode: `{}`\n- description: `{}`\n- execution_profile: `{}`\n- canonical_path: `{}`\n- bundle_root: `{}`\n- prepare_only: `{}`\n- final_verdict: `{}`\n",
         entry.id,
         contract.version,
         contract.entry_mode,
@@ -319,8 +364,12 @@ fn run_generic_pipeline(
         entry.execution_profile.clone().unwrap_or_else(|| contract.execution_profile.clone()),
         pipeline_dir.strip_prefix(&repo_root).unwrap_or(&pipeline_dir).display(),
         bundle_root.display(),
-        options.prepare_only
+        options.prepare_only,
+        final_verdict
     );
+    let mut stage_assets = BTreeMap::new();
+    let mut stage_reports = BTreeMap::new();
+    let mut command_log = Vec::new();
 
     for stage in &contract.stages {
         let asset_path = pipeline_dir.join(&stage.asset);
@@ -333,6 +382,24 @@ fn run_generic_pipeline(
         let packet_path = stage_inputs_dir.join(format!("{}-packet.md", stage.id));
         fs::write(&packet_path, &rendered)?;
         let report_path = reports_dir.join(format!("{}-report.md", stage.id));
+        let log_path = stage_logs_dir.join(format!("{}-executor.log", stage.id));
+        let packet_rel = packet_path
+            .strip_prefix(&bundle_root)
+            .unwrap_or(&packet_path)
+            .display()
+            .to_string();
+        let report_rel = report_path
+            .strip_prefix(&bundle_root)
+            .unwrap_or(&report_path)
+            .display()
+            .to_string();
+        let log_rel = log_path
+            .strip_prefix(&bundle_root)
+            .unwrap_or(&log_path)
+            .display()
+            .to_string();
+        stage_assets.insert(stage.id.clone(), stage.asset.clone());
+        stage_reports.insert(stage.id.clone(), report_rel.clone());
 
         if options.prepare_only {
             fs::write(
@@ -342,6 +409,17 @@ fn run_generic_pipeline(
                     stage.id, stage.kind, stage.asset
                 ),
             )?;
+            fs::write(
+                &log_path,
+                format!(
+                    "prepare-only: stage `{}` was not executed; prompt packet materialized.\n",
+                    stage.id
+                ),
+            )?;
+            command_log.push(format!(
+                "- stage `{}` | kind=`{}` | asset=`{}` | prompt_packet=`{}` | report=`{}` | log=`{}` | executor=`prepare-only`",
+                stage.id, stage.kind, stage.asset, packet_rel, report_rel, log_rel
+            ));
             continue;
         }
 
@@ -362,6 +440,13 @@ fn run_generic_pipeline(
                     format!(
                         "# Synthetic Stage Report\n\n- stage: `{}`\n- kind: `{}`\n",
                         stage.id, stage.kind
+                    ),
+                )?;
+                fs::write(
+                    &log_path,
+                    format!(
+                        "mock executor produced synthetic output for stage `{}`.\n",
+                        stage.id
                     ),
                 )?;
             }
@@ -385,13 +470,21 @@ fn run_generic_pipeline(
                         &rendered,
                     )?
                 };
-                fs::write(
-                    stage_logs_dir.join(format!("{}-executor.log", stage.id)),
-                    &output.stderr,
-                )?;
+                fs::write(&log_path, &output.stderr)?;
                 fs::write(&report_path, &output.stdout)?;
             }
         }
+
+        command_log.push(format!(
+            "- stage `{}` | kind=`{}` | asset=`{}` | prompt_packet=`{}` | report=`{}` | log=`{}` | executor=`{}`",
+            stage.id,
+            stage.kind,
+            stage.asset,
+            packet_rel,
+            report_rel,
+            log_rel,
+            options.executor.as_str()
+        ));
 
         summary.push_str(&format!(
             "- stage `{}` -> `{}`\n",
@@ -403,18 +496,99 @@ fn run_generic_pipeline(
         ));
     }
 
+    let inventory = format!(
+        "# Workflow Bundle Inventory\n\n- workflow_id: `{}`\n- version: `{}`\n- entry_mode: `{}`\n- execution_profile: `{}`\n- bundle_root: `{}`\n{}\n\n## Resolved Inputs\n\n{}\n## Stages\n\n{}\n",
+        entry.id,
+        contract.version,
+        contract.entry_mode,
+        entry.execution_profile.clone().unwrap_or_else(|| contract.execution_profile.clone()),
+        bundle_root.display(),
+        target_root_rel
+            .as_ref()
+            .map(|value| format!("- target_root: `{value}`"))
+            .unwrap_or_else(|| "- target_root: `<none>`".to_string()),
+        if resolved_inputs.is_empty() {
+            "- None\n\n".to_string()
+        } else {
+            resolved_inputs
+                .iter()
+                .map(|(key, value)| format!("- `{key}` = `{value}`"))
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n\n"
+        },
+        contract
+            .stages
+            .iter()
+            .map(|stage| format!(
+                "- `{}` | kind=`{}` | asset=`{}` | report=`{}`",
+                stage.id,
+                stage.kind,
+                stage.asset,
+                stage_reports
+                    .get(&stage.id)
+                    .cloned()
+                    .unwrap_or_else(|| "reports/<missing>".to_string())
+            ))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    fs::write(&inventory_report, inventory)?;
+
+    let commands = format!(
+        "# Workflow Bundle Commands\n\n- workflow_id: `{}`\n- executor: `{}`\n- prepare_only: `{}`\n\n## Stage Packets\n\n{}\n",
+        entry.id,
+        options.executor.as_str(),
+        options.prepare_only,
+        command_log.join("\n")
+    );
+    fs::write(&commands_report, commands)?;
+
     fs::write(&summary_report, summary)?;
+
+    let validation = format!(
+        "# Workflow Bundle Validation\n\n- workflow_id: `{}`\n- final_verdict: `{}`\n- prepare_only: `{}`\n\n## Checks\n\n- [x] `reports/`, `stage-inputs/`, and `stage-logs/` were created\n- [x] `summary.md`, `commands.md`, `validation.md`, and `inventory.md` were written\n- [x] Every declared stage produced a prompt packet and report path\n- [x] Bundle metadata can resolve the internal workflow bundle files\n",
+        entry.id, final_verdict, options.prepare_only
+    );
+    fs::write(&validation_report, validation)?;
+
+    let metadata = WorkflowBundleMetadata {
+        kind: "workflow-execution-bundle".to_string(),
+        id: bundle_root
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("workflow-bundle")
+            .to_string(),
+        workflow_id: entry.id.clone(),
+        version: contract.version.clone(),
+        entry_mode: contract.entry_mode.clone(),
+        execution_profile: entry
+            .execution_profile
+            .clone()
+            .unwrap_or_else(|| contract.execution_profile.clone()),
+        executor: options.executor.as_str().to_string(),
+        prepare_only: options.prepare_only,
+        started_at,
+        completed_at: now_rfc3339()?,
+        summary: "summary.md".to_string(),
+        commands: "commands.md".to_string(),
+        validation: "validation.md".to_string(),
+        inventory: "inventory.md".to_string(),
+        reports_dir: "reports".to_string(),
+        stage_inputs_dir: "stage-inputs".to_string(),
+        stage_logs_dir: "stage-logs".to_string(),
+        final_verdict: final_verdict.clone(),
+        resolved_inputs,
+        stage_assets,
+        stage_reports,
+        target_root: target_root_rel,
+    };
+    fs::write(bundle_root.join("bundle.yml"), serde_yaml::to_string(&metadata)?)?;
 
     Ok(RunPipelineResult {
         bundle_root,
         summary_report,
-        final_verdict: if options.prepare_only {
-            "prepared-only".to_string()
-        } else if options.executor == ExecutorKind::Mock {
-            "mock-executed".to_string()
-        } else {
-            "manual-review-required".to_string()
-        },
+        final_verdict,
     })
 }
 
@@ -636,6 +810,10 @@ fn today_string() -> Result<String> {
     Ok(time::OffsetDateTime::now_utc().format(&format)?)
 }
 
+fn now_rfc3339() -> Result<String> {
+    Ok(time::OffsetDateTime::now_utc().format(&time::format_description::well_known::Rfc3339)?)
+}
+
 fn unique_directory(parent: &Path, stem: &str) -> Result<PathBuf> {
     for idx in 0.. {
         let candidate = if idx == 0 {
@@ -675,5 +853,163 @@ fn slugify(input: &str) -> String {
         "pipeline".to_string()
     } else {
         trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_temp_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "harmony-pipeline-fixture-{}-{}",
+            label,
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("create temp root");
+        root
+    }
+
+    fn seed_generic_workflow_fixture(root: &Path) -> PathBuf {
+        let harmony_dir = root.join(".harmony");
+        let workflows_dir = harmony_dir.join("orchestration/runtime/workflows/test/sample-workflow");
+        fs::create_dir_all(workflows_dir.join("stages")).expect("create workflow stages");
+        fs::create_dir_all(harmony_dir.join("output/reports")).expect("create output root");
+
+        fs::write(
+            harmony_dir.join("orchestration/runtime/workflows/manifest.yml"),
+            r#"workflows:
+  - id: "sample-workflow"
+    path: "test/sample-workflow/"
+    execution_profile: "core"
+"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            harmony_dir.join("orchestration/runtime/workflows/registry.yml"),
+            r#"workflows:
+  sample-workflow:
+    version: "1.0.0"
+"#,
+        )
+        .expect("write registry");
+        fs::write(
+            workflows_dir.join("workflow.yml"),
+            r#"name: "sample-workflow"
+description: "Fixture workflow for workflow bundle contract tests."
+version: "1.0.0"
+entry_mode: "human"
+execution_profile: "core"
+inputs:
+  - name: package_path
+    type: folder
+    required: false
+stages:
+  - id: "01"
+    asset: "stages/01-analyze.md"
+    kind: "analysis"
+  - id: "02"
+    asset: "stages/02-mutate.md"
+    kind: "mutation"
+"#,
+        )
+        .expect("write workflow contract");
+        fs::write(
+            workflows_dir.join("stages/01-analyze.md"),
+            "# Analyze\n\nInspect the fixture.\n",
+        )
+        .expect("write stage 01");
+        fs::write(
+            workflows_dir.join("stages/02-mutate.md"),
+            "# Mutate\n\nWrite a synthetic mutation.\n",
+        )
+        .expect("write stage 02");
+        harmony_dir
+    }
+
+    #[test]
+    fn mock_generic_workflow_materializes_workflow_bundle_contract() {
+        let root = make_temp_root("mock");
+        let harmony_dir = seed_generic_workflow_fixture(&root);
+
+        let result = run_pipeline_from_harmony_dir(
+            &harmony_dir,
+            RunPipelineOptions {
+                pipeline_id: "sample-workflow".to_string(),
+                executor: ExecutorKind::Mock,
+                executor_bin: None,
+                output_slug: Some("fixture".to_string()),
+                model: None,
+                prepare_only: false,
+                input_overrides: HashMap::new(),
+            },
+        )
+        .expect("mock workflow run should succeed");
+
+        let metadata =
+            fs::read_to_string(result.bundle_root.join("bundle.yml")).expect("bundle metadata");
+        let summary =
+            fs::read_to_string(result.bundle_root.join("summary.md")).expect("bundle summary");
+        let commands =
+            fs::read_to_string(result.bundle_root.join("commands.md")).expect("commands log");
+        let inventory =
+            fs::read_to_string(result.bundle_root.join("inventory.md")).expect("inventory log");
+
+        assert_eq!(result.summary_report, result.bundle_root.join("summary.md"));
+        assert!(result
+            .bundle_root
+            .to_string_lossy()
+            .contains(".harmony/output/reports/workflows/"));
+        assert!(metadata.contains("kind: workflow-execution-bundle"));
+        assert!(metadata.contains("summary: summary.md"));
+        assert!(metadata.contains("reports_dir: reports"));
+        assert!(summary.contains("final_verdict: `mock-executed`"));
+        assert!(commands.contains("executor=`mock`"));
+        assert!(inventory.contains("stage `02`") || inventory.contains("`02` | kind=`mutation`"));
+        assert!(result.bundle_root.join("validation.md").is_file());
+        assert!(result.bundle_root.join("reports/01-report.md").is_file());
+        assert!(result.bundle_root.join("reports/02-report.md").is_file());
+        assert!(result.bundle_root.join("stage-inputs/01-packet.md").is_file());
+        assert!(result.bundle_root.join("stage-logs/01-executor.log").is_file());
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn prepare_only_generic_workflow_still_writes_bundle_contract_files() {
+        let root = make_temp_root("prepare-only");
+        let harmony_dir = seed_generic_workflow_fixture(&root);
+
+        let result = run_pipeline_from_harmony_dir(
+            &harmony_dir,
+            RunPipelineOptions {
+                pipeline_id: "sample-workflow".to_string(),
+                executor: ExecutorKind::Auto,
+                executor_bin: None,
+                output_slug: Some("prepare".to_string()),
+                model: None,
+                prepare_only: true,
+                input_overrides: HashMap::new(),
+            },
+        )
+        .expect("prepare-only workflow run should succeed");
+
+        let metadata =
+            fs::read_to_string(result.bundle_root.join("bundle.yml")).expect("bundle metadata");
+        let log =
+            fs::read_to_string(result.bundle_root.join("stage-logs/01-executor.log")).expect("log");
+
+        assert_eq!(result.final_verdict, "prepared-only");
+        assert!(metadata.contains("prepare_only: true"));
+        assert!(metadata.contains("final_verdict: prepared-only"));
+        assert!(result.bundle_root.join("summary.md").is_file());
+        assert!(result.bundle_root.join("commands.md").is_file());
+        assert!(result.bundle_root.join("validation.md").is_file());
+        assert!(result.bundle_root.join("inventory.md").is_file());
+        assert!(log.contains("prepare-only"));
+
+        fs::remove_dir_all(root).ok();
     }
 }

--- a/.harmony/engine/runtime/crates/kernel/src/workflow.rs
+++ b/.harmony/engine/runtime/crates/kernel/src/workflow.rs
@@ -15,7 +15,6 @@ const WORKFLOW_ID: &str = "audit-design-package";
 const WORKFLOW_ROOT_REL: &str =
     ".harmony/orchestration/runtime/workflows/audit/audit-design-package";
 const REPORTS_ROOT_REL: &str = ".harmony/output/reports";
-const AUDIT_BUNDLES_REL: &str = ".harmony/output/reports/audits";
 const WORKFLOW_REPORTS_ROOT_REL: &str = ".harmony/output/reports/workflows";
 const STANDARD_DESIGN_PACKAGE_VALIDATOR_REL: &str =
     ".harmony/assurance/runtime/_ops/scripts/validate-design-package-standard.sh";
@@ -98,7 +97,7 @@ pub enum ExecutorKind {
 }
 
 impl ExecutorKind {
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Auto => "auto",
             Self::Codex => "codex",
@@ -255,6 +254,8 @@ const REPORT_PLACEHOLDERS: &[(&str, &str)] = &[
 
 #[derive(Clone, Debug, Serialize)]
 struct BundleMetadata {
+    kind: String,
+    id: String,
     workflow_id: String,
     package_path: String,
     mode: String,
@@ -263,6 +264,10 @@ struct BundleMetadata {
     slug: String,
     started_at: String,
     completed_at: String,
+    summary: String,
+    reports_dir: String,
+    stage_inputs_dir: String,
+    stage_logs_dir: String,
     selected_stages: Vec<String>,
     report_paths: BTreeMap<String, String>,
     changed_files: BTreeMap<String, Vec<String>>,
@@ -518,11 +523,14 @@ impl Runner {
 
         let workflow_root = repo_root.join(WORKFLOW_ROOT_REL);
         let reports_root = repo_root.join(REPORTS_ROOT_REL);
-        let audit_bundles_root = repo_root.join(AUDIT_BUNDLES_REL);
+        let workflow_bundles_root = repo_root.join(WORKFLOW_REPORTS_ROOT_REL);
         fs::create_dir_all(&reports_root)
             .with_context(|| format!("create reports root {}", reports_root.display()))?;
-        fs::create_dir_all(&audit_bundles_root).with_context(|| {
-            format!("create audit bundles root {}", audit_bundles_root.display())
+        fs::create_dir_all(&workflow_bundles_root).with_context(|| {
+            format!(
+                "create workflow bundles root {}",
+                workflow_bundles_root.display()
+            )
         })?;
 
         let date = today_string()?;
@@ -535,7 +543,10 @@ impl Runner {
                 .to_string()
         }));
 
-        let bundle_root = unique_directory(&audit_bundles_root, &format!("{date}-{target_slug}"))?;
+        let bundle_root = unique_directory(
+            &workflow_bundles_root,
+            &format!("{date}-{WORKFLOW_ID}-{target_slug}"),
+        )?;
         let reports_dir = bundle_root.join("reports");
         let stage_inputs_dir = bundle_root.join("stage-inputs");
         let stage_logs_dir = bundle_root.join("stage-logs");
@@ -1269,6 +1280,12 @@ impl Runner {
         for note in notes {
             body.push_str(&format!("- {note}\n"));
         }
+        fs::write(self.bundle_root.join("summary.md"), &body).with_context(|| {
+            format!(
+                "write bundle summary {}",
+                self.bundle_root.join("summary.md").display()
+            )
+        })?;
         fs::write(&self.summary_report, body)
             .with_context(|| format!("write summary {}", self.summary_report.display()))
     }
@@ -1280,6 +1297,13 @@ impl Runner {
         final_verdict: &str,
     ) -> Result<()> {
         let metadata = BundleMetadata {
+            kind: "workflow-execution-bundle".to_string(),
+            id: self
+                .bundle_root
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("workflow-bundle")
+                .to_string(),
             workflow_id: WORKFLOW_ID.to_string(),
             package_path: rel_path(&self.repo_root, &self.target_package),
             mode: self.options.mode.as_str().to_string(),
@@ -1288,6 +1312,10 @@ impl Runner {
             slug: self.slug.clone(),
             started_at: self.started_at.clone(),
             completed_at: now_rfc3339()?,
+            summary: "summary.md".to_string(),
+            reports_dir: "reports".to_string(),
+            stage_inputs_dir: "stage-inputs".to_string(),
+            stage_logs_dir: "stage-logs".to_string(),
             selected_stages: self
                 .stages
                 .iter()
@@ -2197,6 +2225,11 @@ mod tests {
         assert!(validation.contains("prepared-only"));
         assert!(summary.contains("prepared-only"));
         assert!(prompt_packet.contains("Final Answer Requirement"));
+        assert!(result
+            .bundle_root
+            .to_string_lossy()
+            .contains(".harmony/output/reports/workflows/"));
+        assert!(result.bundle_root.join("summary.md").is_file());
         assert!(result.bundle_root.join("plan.md").is_file());
         assert!(result.bundle_root.join("bundle.yml").is_file());
         fs::remove_dir_all(root).ok();
@@ -2236,6 +2269,11 @@ mod tests {
         assert_eq!(result.final_verdict, "mock-executed");
         assert!(summary.contains("mock-executed"));
         assert!(validation.contains("mock-executed"));
+        assert!(result
+            .bundle_root
+            .to_string_lossy()
+            .contains(".harmony/output/reports/workflows/"));
+        assert!(result.bundle_root.join("summary.md").is_file());
         assert!(package_delta.contains("synthetic-remediation.md"));
         assert!(stage_report.contains("CHANGE MANIFEST"));
         assert!(target_package

--- a/.harmony/engine/runtime/crates/studio/Cargo.toml
+++ b/.harmony/engine/runtime/crates/studio/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_yaml.workspace = true
 walkdir.workspace = true
 slint = "1.15.1"
+harmony_core = { path = "../core" }
 
 [build-dependencies]
 slint-build = "1.15.1"

--- a/.harmony/engine/runtime/crates/studio/README.md
+++ b/.harmony/engine/runtime/crates/studio/README.md
@@ -1,12 +1,14 @@
 # harmony_studio
 
-Desktop workflow studio for Harmony harness projects.
+Desktop workflow and operations studio for Harmony harness projects.
 
 ## Scope
 
 - Workflow inventory and validation overview
 - Dependency graph canvas with pan/zoom/select
 - Workflow detail inspector from parsed `README.md` frontmatter steps
+- Read-only orchestration operations workspace for overview, lookup, runs,
+  incidents, queue, watchers, automations, missions, and playbooks
 - Staged edit buffer with patch preview export
 - Guarded apply flow with transactional rollback
 - Apply audit index, filtering, preview, and path actions

--- a/.harmony/engine/runtime/crates/studio/src/app_state.rs
+++ b/.harmony/engine/runtime/crates/studio/src/app_state.rs
@@ -4,6 +4,7 @@ use crate::workflows::{
     load_workflow_index, validate_snapshot, ValidationIssue, WorkflowIndexSnapshot, WorkflowSummary,
 };
 use anyhow::{anyhow, Result};
+use harmony_core::orchestration::{LookupQuery, OpsSnapshot, OrchestrationInspector};
 use serde_yaml::{Mapping, Value};
 use std::collections::HashMap;
 use std::fs;
@@ -37,6 +38,129 @@ impl AuditStatusFilter {
             Self::All => 0,
             Self::AppliedOnly => 1,
             Self::FailedOnly => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpsSection {
+    Overview,
+    Lookup,
+    Runs,
+    Incidents,
+    Queue,
+    Watchers,
+    Automations,
+    Missions,
+    Playbooks,
+}
+
+impl OpsSection {
+    fn from_mode(mode: i32) -> Self {
+        match mode {
+            1 => Self::Lookup,
+            2 => Self::Runs,
+            3 => Self::Incidents,
+            4 => Self::Queue,
+            5 => Self::Watchers,
+            6 => Self::Automations,
+            7 => Self::Missions,
+            8 => Self::Playbooks,
+            _ => Self::Overview,
+        }
+    }
+
+    fn mode(self) -> i32 {
+        match self {
+            Self::Overview => 0,
+            Self::Lookup => 1,
+            Self::Runs => 2,
+            Self::Incidents => 3,
+            Self::Queue => 4,
+            Self::Watchers => 5,
+            Self::Automations => 6,
+            Self::Missions => 7,
+            Self::Playbooks => 8,
+        }
+    }
+
+    fn title(self) -> &'static str {
+        match self {
+            Self::Overview => "Overview",
+            Self::Lookup => "Lookup",
+            Self::Runs => "Runs",
+            Self::Incidents => "Incidents",
+            Self::Queue => "Queue",
+            Self::Watchers => "Watchers",
+            Self::Automations => "Automations",
+            Self::Missions => "Missions",
+            Self::Playbooks => "Playbooks",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpsLookupMode {
+    DecisionId,
+    RunId,
+    IncidentId,
+    QueueItemId,
+    EventId,
+    AutomationId,
+    WatcherId,
+    MissionId,
+}
+
+impl OpsLookupMode {
+    fn from_mode(mode: i32) -> Self {
+        match mode {
+            1 => Self::RunId,
+            2 => Self::IncidentId,
+            3 => Self::QueueItemId,
+            4 => Self::EventId,
+            5 => Self::AutomationId,
+            6 => Self::WatcherId,
+            7 => Self::MissionId,
+            _ => Self::DecisionId,
+        }
+    }
+
+    fn mode(self) -> i32 {
+        match self {
+            Self::DecisionId => 0,
+            Self::RunId => 1,
+            Self::IncidentId => 2,
+            Self::QueueItemId => 3,
+            Self::EventId => 4,
+            Self::AutomationId => 5,
+            Self::WatcherId => 6,
+            Self::MissionId => 7,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::DecisionId => "Decision",
+            Self::RunId => "Run",
+            Self::IncidentId => "Incident",
+            Self::QueueItemId => "Queue",
+            Self::EventId => "Event",
+            Self::AutomationId => "Automation",
+            Self::WatcherId => "Watcher",
+            Self::MissionId => "Mission",
+        }
+    }
+
+    fn into_query(self, query: &str) -> LookupQuery {
+        match self {
+            Self::DecisionId => LookupQuery::DecisionId(query.to_string()),
+            Self::RunId => LookupQuery::RunId(query.to_string()),
+            Self::IncidentId => LookupQuery::IncidentId(query.to_string()),
+            Self::QueueItemId => LookupQuery::QueueItemId(query.to_string()),
+            Self::EventId => LookupQuery::EventId(query.to_string()),
+            Self::AutomationId => LookupQuery::AutomationId(query.to_string()),
+            Self::WatcherId => LookupQuery::WatcherId(query.to_string()),
+            Self::MissionId => LookupQuery::MissionId(query.to_string()),
         }
     }
 }
@@ -101,6 +225,12 @@ pub struct AppState {
     selected_audit_preview: String,
     patch_preview: String,
     export_status: String,
+    ops_snapshot: OpsSnapshot,
+    ops_status: String,
+    ops_section: OpsSection,
+    ops_lookup_mode: OpsLookupMode,
+    ops_lookup_query: String,
+    ops_lookup_result: String,
 }
 
 impl AppState {
@@ -113,6 +243,19 @@ impl AppState {
             .first()
             .map(|workflow| workflow.id.clone());
         let recent_audits = list_recent_apply_audits(&root, 10).unwrap_or_default();
+        let (ops_snapshot, ops_status) = match load_ops_snapshot(&root) {
+            Ok(snapshot) => {
+                let status = format!(
+                    "Loaded ops snapshot: watchers={} queue_pending={} runs={} incidents={}.",
+                    snapshot.watchers.len(),
+                    snapshot.queue.pending_count,
+                    snapshot.runs.len(),
+                    snapshot.incidents.len()
+                );
+                (snapshot, status)
+            }
+            Err(error) => (empty_ops_snapshot(), format!("Operations snapshot unavailable: {error}")),
+        };
 
         let mut state = Self {
             root,
@@ -134,6 +277,12 @@ impl AppState {
             selected_audit_preview: "# Select an audit entry to preview markdown.\n".to_string(),
             patch_preview: "# No staged edits.\n".to_string(),
             export_status: "No staged edits yet.".to_string(),
+            ops_snapshot,
+            ops_status,
+            ops_section: OpsSection::Overview,
+            ops_lookup_mode: OpsLookupMode::DecisionId,
+            ops_lookup_query: String::new(),
+            ops_lookup_result: "# Enter a canonical id and run a lookup.\n".to_string(),
         };
         state.sync_selected_audit_after_reload(None);
         Ok(state)
@@ -186,6 +335,53 @@ impl AppState {
 
     pub fn audit_status_filter_mode(&self) -> i32 {
         self.audit_status_filter.mode()
+    }
+
+    pub fn ops_status_text(&self) -> String {
+        self.ops_status.clone()
+    }
+
+    pub fn ops_section_mode(&self) -> i32 {
+        self.ops_section.mode()
+    }
+
+    pub fn ops_section_title_text(&self) -> String {
+        self.ops_section.title().to_string()
+    }
+
+    pub fn ops_lookup_mode(&self) -> i32 {
+        self.ops_lookup_mode.mode()
+    }
+
+    pub fn ops_lookup_query_text(&self) -> String {
+        self.ops_lookup_query.clone()
+    }
+
+    pub fn ops_lookup_result_text(&self) -> String {
+        self.ops_lookup_result.clone()
+    }
+
+    pub fn ops_section_body_text(&self) -> String {
+        match self.ops_section {
+            OpsSection::Overview => render_ops_overview(&self.ops_snapshot),
+            OpsSection::Lookup => format!(
+                "# Lookup\n\n- mode: {}\n- query: {}\n\n{}",
+                self.ops_lookup_mode.label(),
+                if self.ops_lookup_query.is_empty() {
+                    "<empty>"
+                } else {
+                    self.ops_lookup_query.as_str()
+                },
+                self.ops_lookup_result
+            ),
+            OpsSection::Runs => render_ops_runs(&self.ops_snapshot),
+            OpsSection::Incidents => render_ops_incidents(&self.ops_snapshot),
+            OpsSection::Queue => render_ops_queue(&self.ops_snapshot),
+            OpsSection::Watchers => render_ops_watchers(&self.ops_snapshot),
+            OpsSection::Automations => render_ops_automations(&self.ops_snapshot),
+            OpsSection::Missions => render_ops_missions(&self.ops_snapshot),
+            OpsSection::Playbooks => render_ops_playbooks(&self.root),
+        }
     }
 
     pub fn audit_items(&self) -> Vec<ApplyAuditItemState> {
@@ -549,6 +745,72 @@ impl AppState {
         self.export_status = format!("Selected audit: {}", self.selected_audit_path);
     }
 
+    pub fn refresh_ops(&mut self) {
+        match load_ops_snapshot(&self.root) {
+            Ok(snapshot) => {
+                self.ops_snapshot = snapshot;
+                self.ops_status = format!(
+                    "Reloaded ops snapshot: watchers={} queue_pending={} runs={} incidents={}.",
+                    self.ops_snapshot.watchers.len(),
+                    self.ops_snapshot.queue.pending_count,
+                    self.ops_snapshot.runs.len(),
+                    self.ops_snapshot.incidents.len()
+                );
+            }
+            Err(error) => {
+                self.ops_status = format!("Failed to reload ops snapshot: {error}");
+            }
+        }
+    }
+
+    pub fn set_ops_section(&mut self, mode: i32) {
+        self.ops_section = OpsSection::from_mode(mode);
+        self.ops_status = format!("Operations section: {}", self.ops_section.title());
+    }
+
+    pub fn set_ops_lookup_mode(&mut self, mode: i32) {
+        self.ops_lookup_mode = OpsLookupMode::from_mode(mode);
+        self.ops_status = format!("Lookup mode: {}", self.ops_lookup_mode.label());
+    }
+
+    pub fn set_ops_lookup_query(&mut self, query: &str) {
+        self.ops_lookup_query = query.to_string();
+    }
+
+    pub fn run_ops_lookup(&mut self) {
+        let query = self.ops_lookup_query.trim();
+        if query.is_empty() {
+            self.ops_lookup_result = "# Lookup\n\n- missing query\n".to_string();
+            self.ops_status = "Lookup query is empty.".to_string();
+            return;
+        }
+
+        let inspector = match OrchestrationInspector::from_repo_root(&self.root) {
+            Ok(inspector) => inspector,
+            Err(error) => {
+                self.ops_lookup_result =
+                    format!("# Lookup Failed\n\nerror: {error}");
+                self.ops_status = format!("Lookup failed: {error}");
+                return;
+            }
+        };
+
+        match inspector.lookup(self.ops_lookup_mode.into_query(query)) {
+            Ok(result) => {
+                self.ops_lookup_result = render_lookup_result(&result);
+                self.ops_status = format!(
+                    "Lookup completed for {} `{}`.",
+                    self.ops_lookup_mode.label(),
+                    query
+                );
+            }
+            Err(error) => {
+                self.ops_lookup_result = format!("# Lookup Failed\n\nerror: {error}");
+                self.ops_status = format!("Lookup failed: {error}");
+            }
+        }
+    }
+
     pub fn open_selected_audit_location(&mut self) -> Result<()> {
         let Some(path) = self.current_selected_audit_path() else {
             self.export_status = "No audit selected to open.".to_string();
@@ -793,8 +1055,265 @@ impl AppState {
         self.base_layout = base_layout;
         self.edges = edges;
         self.selected_workflow_id = selected_workflow_id;
+        if let Ok(snapshot) = load_ops_snapshot(&self.root) {
+            self.ops_snapshot = snapshot;
+        }
         Ok(())
     }
+}
+
+fn load_ops_snapshot(root: &Path) -> Result<OpsSnapshot> {
+    Ok(OrchestrationInspector::from_repo_root(root)?.snapshot()?)
+}
+
+fn empty_ops_snapshot() -> OpsSnapshot {
+    OpsSnapshot {
+        generated_at: "unavailable".to_string(),
+        overview: Default::default(),
+        watchers: Vec::new(),
+        queue: harmony_core::orchestration::QueueSummary {
+            pending_count: 0,
+            claimed_count: 0,
+            retry_count: 0,
+            dead_letter_count: 0,
+            expired_claim_count: 0,
+            oldest_pending_queue_item_id: None,
+            oldest_pending_age_seconds: None,
+            last_receipt_at: None,
+        },
+        automations: Vec::new(),
+        runs: Vec::new(),
+        missions: Vec::new(),
+        incidents: Vec::new(),
+    }
+}
+
+fn render_ops_overview(snapshot: &OpsSnapshot) -> String {
+    format!(
+        "# Overview\n\n- generated_at: `{}`\n- watchers: {} ({} unhealthy)\n- automations: {} ({} attention)\n- runs: {} ({} running)\n- incidents: {} ({} open, {} closure blocked)\n- queue: pending={} claimed={} retry={} dead_letter={} expired_claims={}\n",
+        snapshot.generated_at,
+        snapshot.overview.watcher_count,
+        snapshot.overview.watcher_unhealthy_count,
+        snapshot.overview.automation_count,
+        snapshot.overview.automation_attention_count,
+        snapshot.overview.run_count,
+        snapshot.overview.running_run_count,
+        snapshot.overview.incident_count,
+        snapshot.overview.open_incident_count,
+        snapshot.overview.incident_closure_blocked_count,
+        snapshot.overview.queue_pending_count,
+        snapshot.overview.queue_claimed_count,
+        snapshot.overview.queue_retry_count,
+        snapshot.overview.queue_dead_letter_count,
+        snapshot.overview.queue_expired_claim_count,
+    )
+}
+
+fn render_ops_runs(snapshot: &OpsSnapshot) -> String {
+    if snapshot.runs.is_empty() {
+        return "# Runs\n\n- none\n".to_string();
+    }
+    let mut body = String::from("# Runs\n\n");
+    for run in &snapshot.runs {
+        body.push_str(&format!(
+            "- `{}` status=`{}` recovery=`{}` decision=`{}` evidence=`{}`\n",
+            run.run_id,
+            run.status,
+            run.recovery_status.clone().unwrap_or_else(|| "-".to_string()),
+            run.decision_link_health,
+            run.evidence_link_health
+        ));
+    }
+    body
+}
+
+fn render_ops_incidents(snapshot: &OpsSnapshot) -> String {
+    if snapshot.incidents.is_empty() {
+        return "# Incidents\n\n- none\n".to_string();
+    }
+    let mut body = String::from("# Incidents\n\n");
+    for incident in &snapshot.incidents {
+        body.push_str(&format!(
+            "- `{}` severity=`{}` status=`{}` owner=`{}` closure_ready=`{}` linked_runs={}\n",
+            incident.incident_id,
+            incident.severity,
+            incident.status,
+            incident.owner,
+            incident.closure_ready,
+            if incident.linked_run_ids.is_empty() {
+                "none".to_string()
+            } else {
+                incident.linked_run_ids.join(", ")
+            }
+        ));
+        if !incident.closure_blockers.is_empty() {
+            body.push_str(&format!(
+                "  blockers: {}\n",
+                incident.closure_blockers.join("; ")
+            ));
+        }
+    }
+    body
+}
+
+fn render_ops_queue(snapshot: &OpsSnapshot) -> String {
+    format!(
+        "# Queue\n\n- pending: {}\n- claimed: {}\n- retry: {}\n- dead_letter: {}\n- expired_claims: {}\n- oldest_pending_queue_item_id: {}\n- oldest_pending_age_seconds: {}\n- last_receipt_at: {}\n",
+        snapshot.queue.pending_count,
+        snapshot.queue.claimed_count,
+        snapshot.queue.retry_count,
+        snapshot.queue.dead_letter_count,
+        snapshot.queue.expired_claim_count,
+        snapshot
+            .queue
+            .oldest_pending_queue_item_id
+            .clone()
+            .unwrap_or_else(|| "none".to_string()),
+        snapshot
+            .queue
+            .oldest_pending_age_seconds
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+        snapshot
+            .queue
+            .last_receipt_at
+            .clone()
+            .unwrap_or_else(|| "none".to_string()),
+    )
+}
+
+fn render_ops_watchers(snapshot: &OpsSnapshot) -> String {
+    if snapshot.watchers.is_empty() {
+        return "# Watchers\n\n- none\n".to_string();
+    }
+    let mut body = String::from("# Watchers\n\n");
+    for watcher in &snapshot.watchers {
+        body.push_str(&format!(
+            "- `{}` status=`{}` health=`{}` last_eval=`{}` last_event=`{}` suppressed={}\n",
+            watcher.watcher_id,
+            watcher.status,
+            watcher.health_status,
+            watcher
+                .last_evaluated_at
+                .clone()
+                .unwrap_or_else(|| "none".to_string()),
+            watcher
+                .last_emitted_event_id
+                .clone()
+                .unwrap_or_else(|| "none".to_string()),
+            watcher.suppressed_count
+        ));
+    }
+    body
+}
+
+fn render_ops_automations(snapshot: &OpsSnapshot) -> String {
+    if snapshot.automations.is_empty() {
+        return "# Automations\n\n- none\n".to_string();
+    }
+    let mut body = String::from("# Automations\n\n");
+    for automation in &snapshot.automations {
+        body.push_str(&format!(
+            "- `{}` status=`{}` workflow=`{}` last_attempt=`{}` last_success=`{}` failures={} suppressed={}\n",
+            automation.automation_id,
+            automation.status,
+            automation
+                .workflow_ref
+                .clone()
+                .unwrap_or_else(|| "none".to_string()),
+            automation
+                .last_launch_attempt_at
+                .clone()
+                .unwrap_or_else(|| "none".to_string()),
+            automation
+                .last_successful_run_id
+                .clone()
+                .unwrap_or_else(|| "none".to_string()),
+            automation.failure_count,
+            automation.suppression_count
+        ));
+        if let Some(reason) = &automation.pause_or_error_reason {
+            body.push_str(&format!("  attention: {}\n", reason));
+        }
+    }
+    body
+}
+
+fn render_ops_missions(snapshot: &OpsSnapshot) -> String {
+    if snapshot.missions.is_empty() {
+        return "# Missions\n\n- none\n".to_string();
+    }
+    let mut body = String::from("# Missions\n\n");
+    for mission in &snapshot.missions {
+        body.push_str(&format!(
+            "- `{}` status=`{}` owner=`{}` active_runs={} blocked_tasks={} outstanding_tasks={}\n",
+            mission.mission_id,
+            mission.status,
+            mission.owner,
+            if mission.active_run_ids.is_empty() {
+                "none".to_string()
+            } else {
+                mission.active_run_ids.join(", ")
+            },
+            mission.blocked_task_count,
+            mission.outstanding_task_count
+        ));
+    }
+    body
+}
+
+fn render_ops_playbooks(root: &Path) -> String {
+    let path = root.join(".harmony/orchestration/practices/orchestration-failure-playbooks.md");
+    fs::read_to_string(&path).unwrap_or_else(|_| {
+        "# Playbooks\n\nNo orchestration failure playbooks are available yet.\n".to_string()
+    })
+}
+
+fn render_lookup_result(result: &harmony_core::orchestration::LookupResult) -> String {
+    let mut body = String::new();
+    body.push_str("# Lookup Result\n\n");
+    body.push_str(&format!(
+        "- query_kind: `{}`\n- query_id: `{}`\n\n",
+        result.query_kind, result.query_id
+    ));
+    body.push_str("## Artifacts\n\n");
+    if result.artifacts.is_empty() {
+        body.push_str("- none\n");
+    } else {
+        for artifact in &result.artifacts {
+            body.push_str(&format!(
+                "- `{}` `{}` -> `{}`\n",
+                artifact.kind, artifact.id, artifact.path
+            ));
+            if !artifact.details.is_empty() {
+                let details = artifact
+                    .details
+                    .iter()
+                    .map(|(key, value)| format!("{key}={value}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                body.push_str(&format!("  details: {}\n", details));
+            }
+        }
+    }
+    body.push_str("\n## Relations\n\n");
+    if result.relations.is_empty() {
+        body.push_str("- none\n");
+    } else {
+        for relation in &result.relations {
+            body.push_str(&format!(
+                "- `{}` -> `{}` ({})\n",
+                relation.from, relation.to, relation.relation
+            ));
+        }
+    }
+    if !result.notes.is_empty() {
+        body.push_str("\n## Notes\n\n");
+        for note in &result.notes {
+            body.push_str(&format!("- {}\n", note));
+        }
+    }
+    body
 }
 
 fn build_graph_layout(snapshot: &WorkflowIndexSnapshot) -> (Vec<PositionedNode>, Vec<Edge>) {
@@ -1232,6 +1751,49 @@ mod tests {
         assert_eq!(state.patch_preview_text(), "# No staged edits.\n");
     }
 
+    #[test]
+    fn operations_section_switching_and_lookup_render() {
+        let harness = TempHarness::new("ops-sections");
+        let mut state = AppState::load(harness.root_path()).expect("app state should load");
+
+        assert!(state.ops_section_body_text().contains("# Overview"));
+        assert!(state.ops_status_text().contains("ops snapshot"));
+
+        state.set_ops_section(2);
+        assert_eq!(state.ops_section_title_text(), "Runs");
+        assert!(state.ops_section_body_text().contains("run-001"));
+
+        state.set_ops_lookup_mode(1);
+        state.set_ops_lookup_query("run-001");
+        state.run_ops_lookup();
+        assert!(state.ops_lookup_result_text().contains("dec-001"));
+        assert!(state.ops_lookup_result_text().contains("q-001"));
+    }
+
+    #[test]
+    fn operations_incident_blockers_and_playbooks_render() {
+        let harness = TempHarness::new("ops-blockers");
+        write_file(
+            &harness
+                .root
+                .join(".harmony/orchestration/runtime/incidents/inc-001/incident.yml"),
+            "incident_id: \"inc-001\"\ntitle: \"Example Incident\"\nseverity: \"sev2\"\nstatus: \"open\"\nowner: \"@architect\"\nsummary: \"Incident summary\"\n",
+        );
+        let _ = fs::remove_file(
+            harness
+                .root
+                .join(".harmony/orchestration/runtime/incidents/inc-001/closure.md"),
+        );
+        let mut state = AppState::load(harness.root_path()).expect("app state should load");
+
+        state.set_ops_section(3);
+        assert!(state.ops_section_body_text().contains("missing linked runs"));
+        assert!(state.ops_section_body_text().contains("missing closure.md"));
+
+        state.set_ops_section(8);
+        assert!(state.ops_section_body_text().contains("watcher source unreadable"));
+    }
+
     fn write_fixture_harness(root: &Path) {
         write_file(
             &root.join(".harmony/orchestration/runtime/workflows/manifest.yml"),
@@ -1260,6 +1822,78 @@ mod tests {
         write_file(
             &root.join(".harmony/orchestration/runtime/workflows/beta/workflow.yml"),
             "schema_version: workflow-contract-v1\nname: beta\ndescription: Beta workflow with a missing step file.\nversion: 1.0.0\nentry_mode: human\nexecution_profile: core\nstages:\n  - id: beta-step\n    asset: stages/01-beta.md\n    kind: analysis\nartifacts: []\ndone_gate:\n  checks:\n    - Beta complete\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/runs/run-001.yml"),
+            "run_id: \"run-001\"\nstatus: \"running\"\nstarted_at: \"2026-03-11T10:10:00Z\"\ndecision_id: \"dec-001\"\ncontinuity_run_path: \".harmony/continuity/runs/run-001/\"\nsummary: \"Example run\"\nexecutor_id: \"exec-1\"\nexecutor_acknowledged_at: \"2026-03-11T10:10:01Z\"\nlast_heartbeat_at: \"2026-03-11T10:15:00Z\"\nlease_expires_at: \"2099-03-11T10:20:00Z\"\nrecovery_status: \"healthy\"\nworkflow_ref:\n  workflow_group: \"alpha\"\n  workflow_id: \"alpha\"\nautomation_id: \"example\"\nmission_id: \"example\"\nincident_id: \"inc-001\"\nqueue_item_id: \"q-001\"\nevent_id: \"evt-001\"\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/runs/index.yml"),
+            "schema_version: \"orchestration-runs-index-v1\"\nruns: []\n",
+        );
+        write_file(
+            &root.join(".harmony/continuity/decisions/dec-001/decision.json"),
+            "{\n  \"decision_id\": \"dec-001\",\n  \"outcome\": \"allow\",\n  \"surface\": \"automations\",\n  \"action\": \"launch\",\n  \"actor\": \"example\",\n  \"summary\": \"Allowed.\",\n  \"run_id\": \"run-001\",\n  \"automation_id\": \"example\",\n  \"event_id\": \"evt-001\",\n  \"queue_item_id\": \"q-001\"\n}\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/queue/pending/q-001.json"),
+            "{\n  \"queue_item_id\": \"q-001\",\n  \"target_automation_id\": \"example\",\n  \"status\": \"pending\",\n  \"summary\": \"Queued.\",\n  \"event_id\": \"evt-001\",\n  \"watcher_id\": \"example\",\n  \"payload_ref\": \"/tmp/harmony-studio-ops-event.json\",\n  \"enqueued_at\": \"2026-03-11T10:05:00Z\",\n  \"available_at\": \"2026-03-11T10:05:00Z\"\n}\n",
+        );
+        write_file(
+            &PathBuf::from("/tmp/harmony-studio-ops-event.json"),
+            "{\n  \"event_id\": \"evt-001\",\n  \"emitted_at\": \"2026-03-11T10:04:00Z\"\n}\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/queue/receipts/q-001-ack-20260311T101600Z.json"),
+            "{\n  \"queue_item_id\": \"q-001\",\n  \"handled_at\": \"2026-03-11T10:16:00Z\"\n}\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/automations/example/automation.yml"),
+            "automation_id: \"example\"\ntitle: \"Example Automation\"\nworkflow_ref:\n  workflow_group: \"alpha\"\n  workflow_id: \"alpha\"\nowner: \"@architect\"\nstatus: \"active\"\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/automations/example/state/counters.json"),
+            "{\n  \"blocked\": 2\n}\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/automations/example/state/status.json"),
+            "{\n  \"status\": \"active\"\n}\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/watchers/example/watcher.yml"),
+            "watcher_id: \"example\"\ntitle: \"Example Watcher\"\nowner: \"@architect\"\nstatus: \"active\"\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/watchers/example/state/health.json"),
+            "{\n  \"status\": \"healthy\",\n  \"checked_at\": \"2026-03-11T10:00:00Z\"\n}\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/watchers/example/state/suppressions.json"),
+            "{\n  \"suppressed\": [\"evt-old\"]\n}\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/missions/example/mission.yml"),
+            "schema_version: \"mission-object-v1\"\nmission_id: \"example\"\ntitle: \"Example Mission\"\nsummary: \"Example mission.\"\nstatus: \"active\"\nowner: \"@architect\"\ncreated_at: \"2026-03-10T00:00:00Z\"\nactive_run_ids:\n  - \"run-001\"\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/missions/example/tasks.json"),
+            "{\n  \"tasks\": [\n    {\"id\": \"t1\", \"status\": \"blocked\"},\n    {\"id\": \"t2\", \"status\": \"open\"}\n  ]\n}\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/incidents/inc-001/incident.yml"),
+            "incident_id: \"inc-001\"\ntitle: \"Example Incident\"\nseverity: \"sev2\"\nstatus: \"closed\"\nowner: \"@architect\"\nsummary: \"Incident summary\"\nrun_ids:\n  - \"run-001\"\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/incidents/inc-001/timeline.md"),
+            "# Incident Timeline: inc-001\n\n- 2026-03-11T10:20:00Z: incident updated\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/runtime/incidents/inc-001/closure.md"),
+            "# Incident Closure: inc-001\n\n- Closed At: `2026-03-11T10:30:00Z`\n- Closed By: `@architect`\n- Approval: `appr-001`\n\nClosed with evidence.\n\n## Remediation Evidence\n\n- Remediation Ref: `run:run-001`\n",
+        );
+        write_file(
+            &root.join(".harmony/orchestration/practices/orchestration-failure-playbooks.md"),
+            "# Orchestration Failure Playbooks\n\n## watcher source unreadable\n\n- Inspect watcher health.\n",
         );
     }
 

--- a/.harmony/engine/runtime/crates/studio/src/main.rs
+++ b/.harmony/engine/runtime/crates/studio/src/main.rs
@@ -180,6 +180,56 @@ fn main() -> Result<()> {
         }
     });
 
+    let weak_window = window.as_weak();
+    let state_for_refresh_ops = Rc::clone(&state);
+    window.on_refresh_ops(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_refresh_ops.borrow_mut();
+            state.refresh_ops();
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_set_ops_section = Rc::clone(&state);
+    window.on_set_ops_section(move |mode| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_set_ops_section.borrow_mut();
+            state.set_ops_section(mode);
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_set_ops_lookup_mode = Rc::clone(&state);
+    window.on_set_ops_lookup_mode(move |mode| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_set_ops_lookup_mode.borrow_mut();
+            state.set_ops_lookup_mode(mode);
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_set_ops_lookup_query = Rc::clone(&state);
+    window.on_set_ops_lookup_query(move |query| {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_set_ops_lookup_query.borrow_mut();
+            state.set_ops_lookup_query(query.as_str());
+            refresh_view(&window, &state);
+        }
+    });
+
+    let weak_window = window.as_weak();
+    let state_for_run_ops_lookup = Rc::clone(&state);
+    window.on_run_ops_lookup(move || {
+        if let Some(window) = weak_window.upgrade() {
+            let mut state = state_for_run_ops_lookup.borrow_mut();
+            state.run_ops_lookup();
+            refresh_view(&window, &state);
+        }
+    });
+
     window.run().context("studio window exited with error")
 }
 
@@ -199,6 +249,13 @@ fn refresh_view(window: &AppWindow, state: &AppState) {
     window.set_selected_audit_preview(state.selected_audit_preview_text().into());
     window.set_audit_filter_query(state.audit_filter_query_text().into());
     window.set_audit_status_filter_mode(state.audit_status_filter_mode());
+    window.set_ops_status(state.ops_status_text().into());
+    window.set_ops_section_mode(state.ops_section_mode());
+    window.set_ops_section_title(state.ops_section_title_text().into());
+    window.set_ops_lookup_mode(state.ops_lookup_mode());
+    window.set_ops_lookup_query(state.ops_lookup_query_text().into());
+    window.set_ops_lookup_result(state.ops_lookup_result_text().into());
+    window.set_ops_section_body(state.ops_section_body_text().into());
 
     window.set_selected_title(state.selected_title().into());
     window.set_selected_description(state.selected_description().into());

--- a/.harmony/engine/runtime/crates/studio/ui/app.slint
+++ b/.harmony/engine/runtime/crates/studio/ui/app.slint
@@ -59,7 +59,7 @@ component ActionButton inherits Rectangle {
 export component AppWindow inherits Window {
     title: "Harmony Studio";
     width: 1340px;
-    height: 860px;
+    height: 1220px;
     background: #0e141c;
 
     in-out property <string> root_path: "Locating .harmony root...";
@@ -77,6 +77,13 @@ export component AppWindow inherits Window {
     in-out property <string> selected_audit_preview: "# No apply audits found.\n";
     in-out property <string> audit_filter_query: "";
     in-out property <int> audit_status_filter_mode: 0;
+    in-out property <string> ops_status: "Initializing operations snapshot...";
+    in-out property <int> ops_section_mode: 0;
+    in-out property <string> ops_section_title: "Overview";
+    in-out property <int> ops_lookup_mode: 0;
+    in-out property <string> ops_lookup_query: "";
+    in-out property <string> ops_lookup_result: "# Enter a canonical id and run a lookup.\n";
+    in-out property <string> ops_section_body: "# Overview unavailable.\n";
 
     in-out property <[WorkflowListItem]> workflows;
     in-out property <[GraphNodeItem]> graph_nodes;
@@ -105,6 +112,11 @@ export component AppWindow inherits Window {
     callback copy-selected-audit-path();
     callback set-audit-filter-query(string);
     callback set-audit-status-filter(int);
+    callback refresh-ops();
+    callback set-ops-section(int);
+    callback set-ops-lookup-mode(int);
+    callback set-ops-lookup-query(string);
+    callback run-ops-lookup();
 
     VerticalLayout {
         spacing: 12px;
@@ -423,6 +435,178 @@ export component AppWindow inherits Window {
                             wrap: word-wrap;
                         }
                     }
+                }
+            }
+        }
+
+        Rectangle {
+            border-color: #2c3a49;
+            border-width: 1px;
+            border-radius: 10px;
+            background: #111a24;
+            height: 348px;
+
+            Text {
+                text: "Operations Workspace · " + ops_section_title;
+                color: #e8f1ff;
+                font-size: 18px;
+                x: 14px;
+                y: 12px;
+            }
+
+            ActionButton {
+                x: parent.width - 114px;
+                y: 10px;
+                width: 100px;
+                height: 30px;
+                label: "Refresh";
+                clicked => { root.refresh-ops(); }
+            }
+
+            HorizontalLayout {
+                x: 14px;
+                y: 46px;
+                spacing: 8px;
+
+                ActionButton { width: 96px; height: 28px; label: ops_section_mode == 0 ? "[Overview]" : "Overview"; clicked => { root.set-ops-section(0); } }
+                ActionButton { width: 88px; height: 28px; label: ops_section_mode == 1 ? "[Lookup]" : "Lookup"; clicked => { root.set-ops-section(1); } }
+                ActionButton { width: 72px; height: 28px; label: ops_section_mode == 2 ? "[Runs]" : "Runs"; clicked => { root.set-ops-section(2); } }
+                ActionButton { width: 92px; height: 28px; label: ops_section_mode == 3 ? "[Incidents]" : "Incidents"; clicked => { root.set-ops-section(3); } }
+                ActionButton { width: 76px; height: 28px; label: ops_section_mode == 4 ? "[Queue]" : "Queue"; clicked => { root.set-ops-section(4); } }
+            }
+
+            HorizontalLayout {
+                x: 14px;
+                y: 82px;
+                spacing: 8px;
+
+                ActionButton { width: 92px; height: 28px; label: ops_section_mode == 5 ? "[Watchers]" : "Watchers"; clicked => { root.set-ops-section(5); } }
+                ActionButton { width: 112px; height: 28px; label: ops_section_mode == 6 ? "[Automations]" : "Automations"; clicked => { root.set-ops-section(6); } }
+                ActionButton { width: 92px; height: 28px; label: ops_section_mode == 7 ? "[Missions]" : "Missions"; clicked => { root.set-ops-section(7); } }
+                ActionButton { width: 100px; height: 28px; label: ops_section_mode == 8 ? "[Playbooks]" : "Playbooks"; clicked => { root.set-ops-section(8); } }
+            }
+
+            Rectangle {
+                x: 12px;
+                y: 118px;
+                width: parent.width - 24px;
+                height: 30px;
+                visible: ops_section_mode == 1;
+                border-color: #27374a;
+                border-width: 1px;
+                border-radius: 6px;
+                background: #0f1721;
+
+                lookup_input := TextInput {
+                    x: 8px;
+                    y: 3px;
+                    width: 360px;
+                    height: parent.height - 6px;
+                    text: ops_lookup_query;
+                    edited => { root.set-ops-lookup-query(lookup_input.text); }
+                }
+
+                ActionButton {
+                    x: 376px;
+                    y: 1px;
+                    width: 92px;
+                    height: 28px;
+                    label: ops_lookup_mode == 0 ? "[Decision]" : "Decision";
+                    clicked => { root.set-ops-lookup-mode(0); }
+                }
+                ActionButton {
+                    x: 476px;
+                    y: 1px;
+                    width: 72px;
+                    height: 28px;
+                    label: ops_lookup_mode == 1 ? "[Run]" : "Run";
+                    clicked => { root.set-ops-lookup-mode(1); }
+                }
+                ActionButton {
+                    x: 556px;
+                    y: 1px;
+                    width: 92px;
+                    height: 28px;
+                    label: ops_lookup_mode == 2 ? "[Incident]" : "Incident";
+                    clicked => { root.set-ops-lookup-mode(2); }
+                }
+                ActionButton {
+                    x: 656px;
+                    y: 1px;
+                    width: 78px;
+                    height: 28px;
+                    label: ops_lookup_mode == 3 ? "[Queue]" : "Queue";
+                    clicked => { root.set-ops-lookup-mode(3); }
+                }
+                ActionButton {
+                    x: 742px;
+                    y: 1px;
+                    width: 76px;
+                    height: 28px;
+                    label: ops_lookup_mode == 4 ? "[Event]" : "Event";
+                    clicked => { root.set-ops-lookup-mode(4); }
+                }
+                ActionButton {
+                    x: 826px;
+                    y: 1px;
+                    width: 106px;
+                    height: 28px;
+                    label: ops_lookup_mode == 5 ? "[Automation]" : "Automation";
+                    clicked => { root.set-ops-lookup-mode(5); }
+                }
+                ActionButton {
+                    x: 940px;
+                    y: 1px;
+                    width: 90px;
+                    height: 28px;
+                    label: ops_lookup_mode == 6 ? "[Watcher]" : "Watcher";
+                    clicked => { root.set-ops-lookup-mode(6); }
+                }
+                ActionButton {
+                    x: 1038px;
+                    y: 1px;
+                    width: 88px;
+                    height: 28px;
+                    label: ops_lookup_mode == 7 ? "[Mission]" : "Mission";
+                    clicked => { root.set-ops-lookup-mode(7); }
+                }
+                ActionButton {
+                    x: parent.width - 98px;
+                    y: 1px;
+                    width: 88px;
+                    height: 28px;
+                    label: "Run";
+                    clicked => { root.run-ops-lookup(); }
+                }
+            }
+
+            Text {
+                text: ops_status;
+                color: #a5bed9;
+                x: 14px;
+                y: ops_section_mode == 1 ? 154px : 118px;
+                width: parent.width - 28px;
+                wrap: word-wrap;
+            }
+
+            Rectangle {
+                x: 12px;
+                y: ops_section_mode == 1 ? 182px : 150px;
+                width: parent.width - 24px;
+                height: parent.height - (ops_section_mode == 1 ? 194px : 162px);
+                border-color: #27374a;
+                border-width: 1px;
+                border-radius: 8px;
+                background: #0f1721;
+                clip: true;
+
+                Text {
+                    text: ops_section_mode == 1 ? ops_lookup_result : ops_section_body;
+                    color: #d7e5f8;
+                    x: 10px;
+                    y: 8px;
+                    width: parent.width - 20px;
+                    wrap: word-wrap;
                 }
             }
         }

--- a/.harmony/orchestration/governance/production-incident-runbook.md
+++ b/.harmony/orchestration/governance/production-incident-runbook.md
@@ -11,6 +11,12 @@ When something goes wrong in production, follow this runbook. The golden rule:
 Use `incidents.md` for generic Harmony incident governance. Use this file for
 product-specific operational response steps.
 
+For orchestration-specific lookup, closure readiness, and failure handling,
+also use:
+
+- `/.harmony/orchestration/practices/operator-lookup-and-triage.md`
+- `/.harmony/orchestration/practices/orchestration-failure-playbooks.md`
+
 ## Incident Response Flowchart
 
 ```text
@@ -47,6 +53,9 @@ product-specific operational response steps.
 | Check what changed recently | `harmony changes --recent` |
 | Get AI analysis | `harmony investigate "description"` |
 | End incident | `harmony incident resolve` |
+| Orchestration lookup | `harmony orchestration lookup --incident-id <id>` |
+| Closure readiness | `harmony orchestration incident closure-readiness --incident-id <id>` |
+| Ops snapshot | `harmony orchestration summary --surface all` |
 
 ## Step 1: Rollback (If Recent Deploy)
 
@@ -113,6 +122,23 @@ harmony logs --production --service checkout
 harmony health --external
 ```
 
+### Orchestration-specific investigation
+
+If the issue touches watcher, queue, automation, run, or incident lineage:
+
+```bash
+# Get an orchestration-wide snapshot
+harmony orchestration summary --surface all
+
+# Follow the incident or run lineage
+harmony orchestration lookup --incident-id <incident-id>
+harmony orchestration lookup --run-id <run-id>
+```
+
+Use the scenario-specific response playbooks in
+`/.harmony/orchestration/practices/orchestration-failure-playbooks.md` once the
+failure class is known.
+
 ## Step 4: Communicate
 
 If users are affected:
@@ -158,3 +184,14 @@ AI can draft:
 - contributing factors
 - remediation actions
 - follow-up work
+
+## Step 7: Closure Readiness
+
+Before a human closes an orchestration-linked incident, run:
+
+```bash
+harmony orchestration incident closure-readiness --incident-id <incident-id>
+```
+
+If the readiness check reports blockers, do not close the incident until the
+missing evidence is linked or explicitly waived under policy.

--- a/.harmony/orchestration/practices/README.md
+++ b/.harmony/orchestration/practices/README.md
@@ -26,8 +26,14 @@
   dead-letter discipline for the queue surface.
 - `run-linkage-standards.md` - operating rules for orchestration-facing run
   state and continuity linkage.
+- `operator-lookup-and-triage.md` - preferred lookup order, command path, and
+  triage flow for canonical orchestration identifiers.
 - `incident-lifecycle-standards.md` - operating discipline for runtime incident
   state and evidence-backed closure.
+- `orchestration-failure-playbooks.md` - scenario-specific operator playbooks
+  for watcher, automation, queue, run, and incident failure handling.
+- `campaign-promotion-criteria.md` - standing criteria for when optional
+  `campaigns` should remain deferred or be promoted into live runtime.
 - `orchestration-domain-implementation-agreement.md` - Phase 0 working
   agreement for implementing and promoting the orchestration domain from the
   design package without inventing architecture.

--- a/.harmony/orchestration/practices/campaign-promotion-criteria.md
+++ b/.harmony/orchestration/practices/campaign-promotion-criteria.md
@@ -1,0 +1,88 @@
+# Campaign Promotion Criteria
+
+`campaigns` are an optional orchestration surface. They should only be promoted
+into live Harmony when they solve a real coordination problem that cannot be
+handled cleanly by `missions`, `runs`, `incidents`, and ordinary reports.
+
+## Default Position
+
+- `campaigns` remain deferred by default.
+- A mission may exist without a campaign.
+- `campaigns` are coordination objects, not execution containers.
+- `campaigns` must not become a second mission system.
+
+## Use This Document When
+
+- engineers think multiple missions should roll up under one larger objective
+- operators want a shared milestone or waiver view across missions
+- a future proposal asks to add `/.harmony/orchestration/runtime/campaigns/`
+
+## Promotion Triggers
+
+Promote `campaigns` only when one or more of these are true in live practice:
+
+1. Multiple active missions regularly serve one larger objective.
+2. Two or more missions need shared milestone coordination.
+3. Two or more missions need shared waiver, exception, or unresolved-risk
+   tracking.
+4. Operators need one deterministic portfolio rollup that cannot be expressed
+   cleanly through mission, run, incident, or output-report surfaces.
+
+## Non-Triggers
+
+Do not promote `campaigns` for these reasons alone:
+
+- wanting a cleaner hierarchy on paper
+- wanting labels for loosely related work
+- trying to compensate for weak mission modeling
+- wanting a place to launch workflows directly
+- wanting a place to store run, queue, or incident authority
+
+## Required Evidence Before A Go Decision
+
+Any future promotion proposal must document:
+
+1. The concrete multi-mission objective that exists in live work.
+2. The current coordination pain using only missions, runs, incidents, and
+   reports.
+3. Why that pain is structural rather than temporary or team-specific.
+4. Which operators or workflows will consume campaign rollups.
+5. Why `campaigns` remain aggregation-only and do not need execution authority.
+
+## Promotion Boundaries
+
+If `campaigns` are promoted, they must preserve these boundaries:
+
+- `campaign.yml` is authoritative for campaign identity, lifecycle, mission
+  membership, milestones, and coordination notes.
+- `campaigns` may aggregate mission state, but they do not override mission
+  lifecycle.
+- `campaigns` must not launch workflows, claim queue items, own runs, or own
+  incidents.
+- `campaigns` must not become required for normal-path execution.
+
+## Required Promotion Deliverables
+
+If the decision changes from `no-go` to `go`, the implementation must include:
+
+- `/.harmony/orchestration/runtime/campaigns/README.md`
+- `/.harmony/orchestration/runtime/campaigns/manifest.yml`
+- `/.harmony/orchestration/runtime/campaigns/registry.yml`
+- `/.harmony/orchestration/runtime/campaigns/<campaign-id>/campaign.yml`
+- `/.harmony/orchestration/runtime/campaigns/<campaign-id>/log.md`
+- `/.harmony/orchestration/runtime/campaigns/_ops/scripts/validate-campaigns.sh`
+- practice guidance for campaign lifecycle and operator usage
+- a new evidence-backed go/no-go receipt replacing the current defer decision
+
+## Current Standing Decision
+
+The current live decision is still `no-go`. See:
+
+- `/.harmony/output/plans/2026-03-10-orchestration-domain-phase9-completion-receipt.md`
+
+## Package References
+
+- `/.design-packages/orchestration-domain-design-package/contracts/campaign-object-contract.md`
+- `/.design-packages/orchestration-domain-design-package/contracts/campaign-mission-coordination-contract.md`
+- `/.design-packages/orchestration-domain-design-package/reference/surfaces/campaigns.md`
+- `/.design-packages/orchestration-domain-design-package/navigation/canonicalization-target-map.md`

--- a/.harmony/orchestration/practices/incident-lifecycle-standards.md
+++ b/.harmony/orchestration/practices/incident-lifecycle-standards.md
@@ -15,6 +15,7 @@ Applies to incident opening, enrichment, mitigation tracking, and closure.
 3. `closure.md` is required when `status=closed`.
 4. Closing an incident requires:
    - explicit closure authority
+   - a fail-closed closure-readiness check before the final status transition
    - closure summary
    - remediation evidence or explicit waiver
 5. Incident runtime state must remain subordinate to incident governance:
@@ -26,5 +27,7 @@ Applies to incident opening, enrichment, mitigation tracking, and closure.
 
 - Runtime incidents coordinate response state.
 - Governance remains in `/.harmony/orchestration/governance/incidents.md`.
+- Use `harmony orchestration incident closure-readiness --incident-id <id>`
+  before human closure.
 - Larger follow-up work should move into mission state rather than remaining
   implicit in incident notes.

--- a/.harmony/orchestration/practices/operator-lookup-and-triage.md
+++ b/.harmony/orchestration/practices/operator-lookup-and-triage.md
@@ -1,0 +1,130 @@
+# Operator Lookup And Triage
+
+Operator guidance for inspecting orchestration state through canonical ids and
+subordinate operator helpers.
+
+## Purpose
+
+Use this document when you need to answer:
+
+- what happened?
+- why did it happen?
+- what is running now?
+- what is blocked?
+- what evidence proves the result?
+
+This guidance is operational only. It does not create new execution authority.
+
+## Default Operator Entry Points
+
+Prefer these commands first:
+
+- `harmony orchestration summary --surface all`
+- `harmony orchestration lookup --run-id <run-id>`
+- `harmony orchestration lookup --decision-id <decision-id>`
+- `harmony orchestration lookup --incident-id <incident-id>`
+- `harmony orchestration lookup --queue-item-id <queue-item-id>`
+- `harmony orchestration lookup --event-id <event-id>`
+- `harmony orchestration incident closure-readiness --incident-id <incident-id>`
+
+Use `generate-ops-snapshot.sh` when you need a dated markdown handoff or
+operator summary report.
+
+## Lookup Order
+
+Start from the identifier you already have, then move through the canonical
+lineage in this order:
+
+1. `decision_id`
+   - inspect decision outcome, reason codes, approval refs, and linked run or
+     incident ids
+2. `run_id`
+   - inspect orchestration-facing run state, recovery status, and continuity
+     evidence linkage
+3. `queue_item_id`
+   - inspect current lane, claim/lease state, target automation, and receipts
+4. `event_id`
+   - inspect watcher event lineage and all downstream queue/run/incident links
+5. `incident_id`
+   - inspect status, severity, owner, linked runs, and closure blockers
+6. `mission_id`
+   - inspect mission status, owner, linked runs, and outstanding bounded work
+
+## Practical Triage Flow
+
+1. Start with `summary --surface all`.
+2. If one incident already exists, pivot to `lookup --incident-id`.
+3. If the problem is execution-specific, pivot to `lookup --run-id`.
+4. If the problem is ingress-specific, pivot to `lookup --queue-item-id` or
+   `lookup --event-id`.
+5. If closure is under consideration, run the closure-readiness check before
+   any human closes the incident.
+
+## Surface-Specific Questions
+
+### Runs
+
+Check:
+
+- status
+- recovery status
+- decision link health
+- continuity evidence link health
+- lease and heartbeat timestamps
+
+### Queue
+
+Check:
+
+- lane counts
+- oldest pending age
+- expired lease count
+- dead-letter count
+- receipt presence for handled items
+
+### Watchers
+
+Check:
+
+- status
+- last evaluation time
+- last emitted event
+- suppressed count
+- health or error reason
+
+### Automations
+
+Check:
+
+- status
+- last launch attempt
+- last successful run
+- suppression count
+- pause or error reason
+
+### Incidents
+
+Check:
+
+- severity
+- owner
+- last timeline update
+- linked runs
+- closure blockers
+
+## Escalation Rules
+
+Escalate immediately when:
+
+- a required lineage hop is missing
+- a run is active with expired heartbeat or lease
+- the queue shows repeated expiry or dead-letter growth
+- incident closure readiness reports missing mandatory evidence
+- the next step would require a policy exception or break-glass action
+
+## Boundary
+
+- Treat command output as a projection over canonical artifacts.
+- Do not edit runtime or governance files directly as part of triage.
+- Use the failure playbooks when a specific failure class is known:
+  - `orchestration-failure-playbooks.md`

--- a/.harmony/orchestration/practices/orchestration-domain-implementation-agreement.md
+++ b/.harmony/orchestration/practices/orchestration-domain-implementation-agreement.md
@@ -52,6 +52,8 @@ ownership.
    - `campaigns` are deferred by default.
    - Promote `campaigns` only when multi-mission coordination pressure is
      demonstrated and documented.
+   - Use `campaign-promotion-criteria.md` as the standing live decision guide
+     before reopening the `campaigns` surface.
 
 ## Current Surface Decision
 

--- a/.harmony/orchestration/practices/orchestration-failure-playbooks.md
+++ b/.harmony/orchestration/practices/orchestration-failure-playbooks.md
@@ -1,0 +1,162 @@
+# Orchestration Failure Playbooks
+
+Operator playbooks for the most common orchestration failure classes.
+
+## Purpose
+
+These playbooks define:
+
+- the first reversible action
+- the artifacts to inspect
+- the command path to use
+- the escalation point
+
+They do not authorize policy exceptions.
+
+## 1. Watcher Source Unreadable
+
+Use when:
+
+- watcher health reports `error`
+- the source path cannot be read
+- no recent watcher evaluation is visible
+
+First reversible action:
+
+- pause the affected watcher if it is emitting unreliable signals
+
+Inspect:
+
+- `harmony orchestration summary --surface watchers`
+- `harmony orchestration lookup --watcher-id <watcher-id>`
+- watcher `state/health.json`
+- watcher source definition in `sources.yml`
+
+Escalate when:
+
+- the unreadable source affects incident-worthy automation paths
+- repeated source failures suggest broader filesystem or authority problems
+
+## 2. Automation Target Workflow Unresolved
+
+Use when:
+
+- automation health shows target resolution failure
+- event routing succeeds but launch admission blocks
+
+First reversible action:
+
+- pause the affected automation rather than mutating watcher definitions or
+  queue state
+
+Inspect:
+
+- `harmony orchestration summary --surface automations`
+- `harmony orchestration lookup --automation-id <automation-id>`
+- automation `automation.yml`
+- workflow discovery via workflow manifest and registry
+
+Escalate when:
+
+- the unresolved target affects multiple automations
+- the workflow has drifted from its canonical contract or discovery path
+
+## 3. Queue Item Expired Without Ack
+
+Use when:
+
+- queue summary shows expired leases or retry/dead-letter growth
+- a queue item moved out of `claimed/` after lease expiry
+
+First reversible action:
+
+- inspect the item and receipt history before replaying or force-acknowledging
+
+Inspect:
+
+- `harmony orchestration summary --surface queue`
+- `harmony orchestration lookup --queue-item-id <queue-item-id>`
+- queue lane file and any matching receipt entries
+- linked run or decision, if any
+
+Escalate when:
+
+- expiry repeats for the same automation or executor path
+- dead-letter growth suggests systemic execution or lease problems
+
+## 4. Stale Acknowledgement With Wrong `claim_token`
+
+Use when:
+
+- ack fails because the supplied `claim_token` does not match
+- receipts exist but the queue item was not correctly finalized
+
+First reversible action:
+
+- stop retrying the stale ack and inspect current queue ownership
+
+Inspect:
+
+- `harmony orchestration lookup --queue-item-id <queue-item-id>`
+- queue receipt entries
+- queue item current lane and claim metadata
+
+Escalate when:
+
+- claim-token mismatches are recurring
+- multiple executors appear to be contending for the same queue item
+
+## 5. Active Run Missing Acknowledgement Or Heartbeat
+
+Use when:
+
+- run health shows expired heartbeat
+- run health shows missing acknowledgement
+- recovery status becomes non-healthy
+
+First reversible action:
+
+- contain the affected automation or incident path before launching more work
+
+Inspect:
+
+- `harmony orchestration summary --surface runs`
+- `harmony orchestration lookup --run-id <run-id>`
+- run lease and heartbeat timestamps
+- linked decision, queue item, and continuity evidence
+
+Escalate when:
+
+- recovery status is `recovery_pending`
+- the same executor path repeatedly loses acknowledgement or heartbeat
+
+## 6. Incident Closure Blocked By Missing Evidence
+
+Use when:
+
+- an operator wants to close an incident
+- closure readiness reports blockers
+- closure.md exists but readiness still fails
+
+First reversible action:
+
+- do not close the incident; gather or explicitly waive the missing evidence
+
+Inspect:
+
+- `harmony orchestration lookup --incident-id <incident-id>`
+- `harmony orchestration incident closure-readiness --incident-id <incident-id>`
+- linked runs, remediation refs, waiver refs, and approval artifacts
+
+Escalate when:
+
+- required evidence cannot be produced
+- closure would require a policy exception or severity downgrade
+
+## Boundary
+
+- Prefer the smallest reversible intervention first.
+- Use incident governance for closure authority:
+  - `/.harmony/orchestration/governance/incidents.md`
+- Use the production runbook for product rollback and deploy handling:
+  - `/.harmony/orchestration/governance/production-incident-runbook.md`

--- a/.harmony/orchestration/runtime/README.md
+++ b/.harmony/orchestration/runtime/README.md
@@ -16,6 +16,32 @@
 | `_coordination/` | Internal lock state for target-global coordination | direct path |
 | `_ops/scripts/validate-orchestration-runtime.sh` | Runtime validation dispatcher for live and planned orchestration surfaces | direct invocation |
 
+## Operator Inspection
+
+Preferred operator entry points for this runtime are:
+
+- `harmony orchestration summary --surface all`
+- `harmony orchestration lookup --run-id <run-id>`
+- `harmony orchestration lookup --decision-id <decision-id>`
+- `harmony orchestration lookup --incident-id <incident-id>`
+- `harmony orchestration incident closure-readiness --incident-id <incident-id>`
+
+Thin wrappers for common operator tasks live under `runtime/_ops/scripts/`,
+including:
+
+- `lookup-orchestration-lineage.sh`
+- `inspect-run-health.sh`
+- `summarize-watcher-health.sh`
+- `summarize-queue-health.sh`
+- `summarize-automation-health.sh`
+- `summarize-mission-health.sh`
+- `summarize-incident-health.sh`
+- `check-incident-closure-readiness.sh`
+- `generate-ops-snapshot.sh`
+
+These helpers remain projection-only over canonical runtime, governance, and
+continuity artifacts.
+
 ## Boundary
 
 Only runtime orchestration artifacts belong here.

--- a/.harmony/orchestration/runtime/_ops/scripts/check-incident-closure-readiness.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/check-incident-closure-readiness.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+orchestration_runtime_run_kernel orchestration incident closure-readiness "$@"

--- a/.harmony/orchestration/runtime/_ops/scripts/generate-ops-snapshot.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/generate-ops-snapshot.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+report_path="$HARMONY_DIR/output/reports/$(date -u +%F)-orchestration-ops-snapshot.md"
+orchestration_runtime_run_kernel orchestration summary --surface all --format markdown --output-report "$report_path" >/dev/null
+printf '%s\n' "$report_path"

--- a/.harmony/orchestration/runtime/_ops/scripts/inspect-run-health.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/inspect-run-health.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+orchestration_runtime_run_kernel orchestration lookup "$@"

--- a/.harmony/orchestration/runtime/_ops/scripts/lookup-orchestration-lineage.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/lookup-orchestration-lineage.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+orchestration_runtime_run_kernel orchestration lookup "$@"

--- a/.harmony/orchestration/runtime/_ops/scripts/orchestration-runtime-common.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/orchestration-runtime-common.sh
@@ -5,11 +5,12 @@ orchestration_runtime_init() {
   ORCH_COMMON_SCRIPT_DIR="$(cd -- "$(dirname -- "$caller_script")" && pwd)"
   ORCH_RUNTIME_DIR="$(cd -- "$ORCH_COMMON_SCRIPT_DIR/../.." && pwd)"
   ORCHESTRATION_DIR="$(cd -- "$ORCH_RUNTIME_DIR/.." && pwd)"
+  TOOL_HARMONY_DIR="$(cd -- "$ORCHESTRATION_DIR/.." && pwd)"
   if [[ -n "${HARMONY_DIR_OVERRIDE:-}" ]]; then
     HARMONY_DIR="$HARMONY_DIR_OVERRIDE"
     ROOT_DIR="${HARMONY_ROOT_DIR:-$(cd -- "$HARMONY_DIR/.." && pwd)}"
   else
-    HARMONY_DIR="$(cd -- "$ORCHESTRATION_DIR/.." && pwd)"
+    HARMONY_DIR="$TOOL_HARMONY_DIR"
     ROOT_DIR="$(cd -- "$HARMONY_DIR/.." && pwd)"
   fi
 
@@ -23,6 +24,7 @@ orchestration_runtime_init() {
   MISSIONS_DIR="$RUNTIME_DIR/missions"
   COORDINATION_DIR="$RUNTIME_DIR/_coordination"
   LOCKS_DIR="$COORDINATION_DIR/locks"
+  HARMONY_KERNEL_RUNNER="$TOOL_HARMONY_DIR/engine/runtime/run"
 }
 
 require_tools() {
@@ -41,6 +43,14 @@ ensure_dir() {
 
 now_utc() {
   date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+orchestration_runtime_run_kernel() {
+  local cwd="${HARMONY_ROOT_DIR:-$ROOT_DIR}"
+  (
+    cd "$cwd"
+    "$HARMONY_KERNEL_RUNNER" "$@"
+  )
 }
 
 next_expiry() {

--- a/.harmony/orchestration/runtime/_ops/scripts/summarize-automation-health.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/summarize-automation-health.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+orchestration_runtime_run_kernel orchestration summary --surface automations "$@"

--- a/.harmony/orchestration/runtime/_ops/scripts/summarize-incident-health.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/summarize-incident-health.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+orchestration_runtime_run_kernel orchestration summary --surface incidents "$@"

--- a/.harmony/orchestration/runtime/_ops/scripts/summarize-mission-health.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/summarize-mission-health.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+orchestration_runtime_run_kernel orchestration summary --surface missions "$@"

--- a/.harmony/orchestration/runtime/_ops/scripts/summarize-queue-health.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/summarize-queue-health.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+orchestration_runtime_run_kernel orchestration summary --surface queue "$@"

--- a/.harmony/orchestration/runtime/_ops/scripts/summarize-watcher-health.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/summarize-watcher-health.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orchestration-runtime-common.sh"
+orchestration_runtime_init "${BASH_SOURCE[0]}"
+
+orchestration_runtime_run_kernel orchestration summary --surface watchers "$@"

--- a/.harmony/orchestration/runtime/_ops/scripts/validate-orchestration-runtime.sh
+++ b/.harmony/orchestration/runtime/_ops/scripts/validate-orchestration-runtime.sh
@@ -55,3 +55,10 @@ if [[ -f "$incident_approval_test" && "${ORCHESTRATION_RUNTIME_SKIP_INCIDENT_APP
   bash "$incident_approval_test"
   echo
 fi
+
+operator_hardening_test="$RUNTIME_DIR/_ops/tests/test-operator-hardening.sh"
+if [[ -f "$operator_hardening_test" && "${ORCHESTRATION_RUNTIME_SKIP_OPERATOR_HARDENING_TEST:-0}" != "1" ]]; then
+  echo "== Run ${operator_hardening_test#$RUNTIME_DIR/} =="
+  bash "$operator_hardening_test"
+  echo
+fi

--- a/.harmony/orchestration/runtime/_ops/tests/test-operator-hardening.sh
+++ b/.harmony/orchestration/runtime/_ops/tests/test-operator-hardening.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+OPS_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+RUNTIME_DIR="$(cd -- "$OPS_DIR/.." && pwd)"
+ORCHESTRATION_DIR="$(cd -- "$RUNTIME_DIR/.." && pwd)"
+HARMONY_DIR="$(cd -- "$ORCHESTRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd -- "$HARMONY_DIR/.." && pwd)"
+
+LOOKUP_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/lookup-orchestration-lineage.sh"
+RUN_HEALTH_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/inspect-run-health.sh"
+WATCHER_SUMMARY_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/summarize-watcher-health.sh"
+QUEUE_SUMMARY_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/summarize-queue-health.sh"
+AUTOMATION_SUMMARY_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/summarize-automation-health.sh"
+MISSION_SUMMARY_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/summarize-mission-health.sh"
+INCIDENT_SUMMARY_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/summarize-incident-health.sh"
+CLOSURE_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/check-incident-closure-readiness.sh"
+SNAPSHOT_SCRIPT=".harmony/orchestration/runtime/_ops/scripts/generate-ops-snapshot.sh"
+
+pass_count=0
+fail_count=0
+cleanup_paths=()
+
+cleanup() {
+  local path
+  for path in "${cleanup_paths[@]}"; do
+    [[ -n "$path" ]] && rm -rf "$path"
+  done
+  rm -f /tmp/harmony-orch-ops-event.json
+}
+trap cleanup EXIT
+
+pass() {
+  echo "PASS: $1"
+  pass_count=$((pass_count + 1))
+}
+
+fail() {
+  echo "FAIL: $1" >&2
+  fail_count=$((fail_count + 1))
+}
+
+assert_success() {
+  local name="$1"
+  shift
+  if "$@"; then
+    pass "$name"
+  else
+    fail "$name"
+  fi
+}
+
+snapshot_runtime_tree() {
+  local fixture_root="$1"
+  (
+    cd "$fixture_root"
+    find .harmony/orchestration .harmony/continuity -type f -print | sort | while IFS= read -r file; do
+      shasum "$file"
+    done
+  )
+}
+
+create_fixture() {
+  local fixture_root
+  fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/orchestration-operator.XXXXXX")"
+  cleanup_paths+=("$fixture_root")
+
+  mkdir -p \
+    "$fixture_root/.harmony/orchestration/runtime/runs/by-surface/workflows" \
+    "$fixture_root/.harmony/orchestration/runtime/runs/by-surface/missions" \
+    "$fixture_root/.harmony/orchestration/runtime/runs/by-surface/automations" \
+    "$fixture_root/.harmony/orchestration/runtime/runs/by-surface/incidents" \
+    "$fixture_root/.harmony/orchestration/runtime/queue/pending" \
+    "$fixture_root/.harmony/orchestration/runtime/queue/claimed" \
+    "$fixture_root/.harmony/orchestration/runtime/queue/retry" \
+    "$fixture_root/.harmony/orchestration/runtime/queue/dead-letter" \
+    "$fixture_root/.harmony/orchestration/runtime/queue/receipts" \
+    "$fixture_root/.harmony/orchestration/runtime/watchers/example/state" \
+    "$fixture_root/.harmony/orchestration/runtime/automations/example/state" \
+    "$fixture_root/.harmony/orchestration/runtime/missions/example/context" \
+    "$fixture_root/.harmony/orchestration/runtime/incidents/inc-001" \
+    "$fixture_root/.harmony/orchestration/runtime/workflows/example/sample" \
+    "$fixture_root/.harmony/continuity/decisions/dec-001" \
+    "$fixture_root/.harmony/continuity/runs/run-001" \
+    "$fixture_root/.harmony/orchestration/governance" \
+    "$fixture_root/.harmony/output/reports"
+
+  cat > "$fixture_root/.harmony/orchestration/runtime/queue/registry.yml" <<'EOF'
+schema_version: "orchestration-queue-registry-v1"
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/runs/index.yml" <<'EOF'
+schema_version: "orchestration-runs-index-v1"
+runs: []
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/incidents/index.yml" <<'EOF'
+schema_version: "orchestration-incidents-index-v1"
+incidents: []
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/missions/registry.yml" <<'EOF'
+schema_version: "1.0"
+active: []
+archived: []
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/watchers/example/watcher.yml" <<'EOF'
+watcher_id: "example"
+title: "Example Watcher"
+owner: "@architect"
+status: "active"
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/watchers/example/state/health.json" <<'EOF'
+{
+  "status": "healthy",
+  "checked_at": "2026-03-11T10:00:00Z"
+}
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/watchers/example/state/suppressions.json" <<'EOF'
+{
+  "suppressed": ["evt-old"]
+}
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/automations/example/automation.yml" <<'EOF'
+automation_id: "example"
+title: "Example Automation"
+workflow_ref:
+  workflow_group: "example"
+  workflow_id: "sample"
+owner: "@architect"
+status: "active"
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/automations/example/state/counters.json" <<'EOF'
+{
+  "blocked": 2
+}
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/automations/example/state/status.json" <<'EOF'
+{
+  "status": "active"
+}
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/missions/example/mission.yml" <<'EOF'
+schema_version: "mission-object-v1"
+mission_id: "example"
+title: "Example Mission"
+summary: "Example mission."
+status: "active"
+owner: "@architect"
+created_at: "2026-03-10T00:00:00Z"
+active_run_ids:
+  - "run-001"
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/missions/example/tasks.json" <<'EOF'
+{
+  "tasks": [
+    {"id": "t1", "status": "blocked"},
+    {"id": "t2", "status": "open"},
+    {"id": "t3", "status": "done"}
+  ]
+}
+EOF
+  cat > "$fixture_root/.harmony/continuity/decisions/dec-001/decision.json" <<'EOF'
+{
+  "decision_id": "dec-001",
+  "outcome": "allow",
+  "surface": "automations",
+  "action": "launch",
+  "actor": "example",
+  "summary": "Allowed.",
+  "run_id": "run-001",
+  "automation_id": "example",
+  "event_id": "evt-001",
+  "queue_item_id": "q-001",
+  "workflow_ref": {
+    "workflow_group": "example",
+    "workflow_id": "sample"
+  }
+}
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/runs/run-001.yml" <<'EOF'
+run_id: "run-001"
+status: "running"
+started_at: "2026-03-11T10:10:00Z"
+decision_id: "dec-001"
+continuity_run_path: ".harmony/continuity/runs/run-001/"
+summary: "Example run"
+executor_id: "exec-1"
+executor_acknowledged_at: "2026-03-11T10:10:01Z"
+last_heartbeat_at: "2026-03-11T10:15:00Z"
+lease_expires_at: "2099-03-11T10:20:00Z"
+recovery_status: "healthy"
+workflow_ref:
+  workflow_group: "example"
+  workflow_id: "sample"
+automation_id: "example"
+mission_id: "example"
+incident_id: "inc-001"
+queue_item_id: "q-001"
+event_id: "evt-001"
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/queue/pending/q-001.json" <<'EOF'
+{
+  "queue_item_id": "q-001",
+  "target_automation_id": "example",
+  "status": "pending",
+  "summary": "Queued.",
+  "event_id": "evt-001",
+  "watcher_id": "example",
+  "payload_ref": "/tmp/harmony-orch-ops-event.json",
+  "enqueued_at": "2026-03-11T10:05:00Z",
+  "available_at": "2026-03-11T10:05:00Z"
+}
+EOF
+  cat > /tmp/harmony-orch-ops-event.json <<'EOF'
+{
+  "event_id": "evt-001",
+  "emitted_at": "2026-03-11T10:04:00Z"
+}
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/queue/receipts/q-001-ack-20260311T101600Z.json" <<'EOF'
+{
+  "queue_item_id": "q-001",
+  "handled_at": "2026-03-11T10:16:00Z"
+}
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/incidents/inc-001/incident.yml" <<'EOF'
+incident_id: "inc-001"
+title: "Example Incident"
+severity: "sev2"
+status: "closed"
+owner: "@architect"
+summary: "Incident summary"
+run_ids:
+  - "run-001"
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/incidents/inc-001/timeline.md" <<'EOF'
+# Incident Timeline: inc-001
+
+- 2026-03-11T10:20:00Z: incident updated
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/incidents/inc-001/closure.md" <<'EOF'
+# Incident Closure: inc-001
+
+- Closed At: `2026-03-11T10:30:00Z`
+- Closed By: `@architect`
+- Approval: `appr-001`
+
+Closed with evidence.
+
+## Remediation Evidence
+
+- Remediation Ref: `run:run-001`
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/workflows/example/sample/workflow.yml" <<'EOF'
+schema_version: "workflow-contract-v1"
+name: "sample"
+description: "Example workflow."
+version: "1.0.0"
+entry_mode: "human"
+execution_profile: "core"
+stages: []
+done_gate:
+  checks: []
+EOF
+
+  printf '%s\n' "$fixture_root"
+}
+
+case_lookup_and_summary_commands() {
+  local fixture_root envs run_lookup event_lookup queue_summary watcher_summary automation_summary mission_summary incident_summary
+  fixture_root="$(create_fixture)"
+  envs=("HARMONY_DIR_OVERRIDE=$fixture_root/.harmony" "HARMONY_ROOT_DIR=$fixture_root" "HARMONY_RUNTIME_PREFER_SOURCE=1")
+
+  run_lookup="$(env "${envs[@]}" bash "$REPO_ROOT/$LOOKUP_SCRIPT" --run-id run-001)"
+  jq -e '.artifacts | any(.kind == "decision" and .id == "dec-001") and any(.kind == "queue_item" and .id == "q-001")' <<<"$run_lookup" >/dev/null
+
+  event_lookup="$(env "${envs[@]}" bash "$REPO_ROOT/$LOOKUP_SCRIPT" --event-id evt-001)"
+  jq -e '.artifacts | any(.kind == "run" and .id == "run-001") and any(.kind == "queue_item" and .id == "q-001")' <<<"$event_lookup" >/dev/null
+
+  queue_summary="$(env "${envs[@]}" bash "$REPO_ROOT/$QUEUE_SUMMARY_SCRIPT")"
+  jq -e '.payload.pending_count == 1 and .payload.last_receipt_at == "2026-03-11T10:16:00Z"' <<<"$queue_summary" >/dev/null
+
+  watcher_summary="$(env "${envs[@]}" bash "$REPO_ROOT/$WATCHER_SUMMARY_SCRIPT")"
+  jq -e '.payload[0].watcher_id == "example" and .payload[0].suppressed_count == 1' <<<"$watcher_summary" >/dev/null
+
+  automation_summary="$(env "${envs[@]}" bash "$REPO_ROOT/$AUTOMATION_SUMMARY_SCRIPT")"
+  jq -e '.payload[0].automation_id == "example" and .payload[0].suppression_count == 2' <<<"$automation_summary" >/dev/null
+
+  mission_summary="$(env "${envs[@]}" bash "$REPO_ROOT/$MISSION_SUMMARY_SCRIPT")"
+  jq -e '.payload[0].mission_id == "example" and .payload[0].blocked_task_count == 1' <<<"$mission_summary" >/dev/null
+
+  incident_summary="$(env "${envs[@]}" bash "$REPO_ROOT/$INCIDENT_SUMMARY_SCRIPT")"
+  jq -e '.payload[0].incident_id == "inc-001" and .payload[0].closure_ready == true' <<<"$incident_summary" >/dev/null
+}
+
+case_run_health_and_closure_readiness() {
+  local fixture_root envs run_health blocked_readiness ready_readiness
+  fixture_root="$(create_fixture)"
+  envs=("HARMONY_DIR_OVERRIDE=$fixture_root/.harmony" "HARMONY_ROOT_DIR=$fixture_root" "HARMONY_RUNTIME_PREFER_SOURCE=1")
+
+  run_health="$(env "${envs[@]}" bash "$REPO_ROOT/$RUN_HEALTH_SCRIPT" --run-id run-001)"
+  jq -e '.artifacts | any(.kind == "run" and .details.decision_link_health == "healthy" and .details.evidence_link_health == "healthy")' <<<"$run_health" >/dev/null
+
+  cat > "$fixture_root/.harmony/orchestration/runtime/incidents/inc-001/incident.yml" <<'EOF'
+incident_id: "inc-001"
+title: "Example Incident"
+severity: "sev2"
+status: "open"
+owner: "@architect"
+summary: "Incident summary"
+EOF
+  rm -f "$fixture_root/.harmony/orchestration/runtime/incidents/inc-001/closure.md"
+  blocked_readiness="$(env "${envs[@]}" bash "$REPO_ROOT/$CLOSURE_SCRIPT" --incident-id inc-001)"
+  jq -e '.ready == false and (.blockers | index("missing linked runs")) != null and (.blockers | index("missing closure.md")) != null' <<<"$blocked_readiness" >/dev/null
+
+  cat > "$fixture_root/.harmony/orchestration/runtime/incidents/inc-001/incident.yml" <<'EOF'
+incident_id: "inc-001"
+title: "Example Incident"
+severity: "sev2"
+status: "closed"
+owner: "@architect"
+summary: "Incident summary"
+run_ids:
+  - "run-001"
+EOF
+  cat > "$fixture_root/.harmony/orchestration/runtime/incidents/inc-001/closure.md" <<'EOF'
+# Incident Closure: inc-001
+
+- Closed At: `2026-03-11T10:30:00Z`
+- Closed By: `@architect`
+- Approval: `appr-001`
+
+Closed with evidence.
+
+## Remediation Evidence
+
+- Remediation Ref: `run:run-001`
+EOF
+  ready_readiness="$(env "${envs[@]}" bash "$REPO_ROOT/$CLOSURE_SCRIPT" --incident-id inc-001)"
+  jq -e '.ready == true and (.blockers | length) == 0' <<<"$ready_readiness" >/dev/null
+}
+
+case_wrappers_are_read_only_and_snapshot_writes_report() {
+  local fixture_root envs before after report_path
+  fixture_root="$(create_fixture)"
+  envs=("HARMONY_DIR_OVERRIDE=$fixture_root/.harmony" "HARMONY_ROOT_DIR=$fixture_root" "HARMONY_RUNTIME_PREFER_SOURCE=1")
+
+  before="$(snapshot_runtime_tree "$fixture_root")"
+  env "${envs[@]}" bash "$REPO_ROOT/$LOOKUP_SCRIPT" --run-id run-001 >/dev/null
+  env "${envs[@]}" bash "$REPO_ROOT/$RUN_HEALTH_SCRIPT" --run-id run-001 >/dev/null
+  env "${envs[@]}" bash "$REPO_ROOT/$WATCHER_SUMMARY_SCRIPT" >/dev/null
+  env "${envs[@]}" bash "$REPO_ROOT/$QUEUE_SUMMARY_SCRIPT" >/dev/null
+  env "${envs[@]}" bash "$REPO_ROOT/$AUTOMATION_SUMMARY_SCRIPT" >/dev/null
+  env "${envs[@]}" bash "$REPO_ROOT/$MISSION_SUMMARY_SCRIPT" >/dev/null
+  env "${envs[@]}" bash "$REPO_ROOT/$INCIDENT_SUMMARY_SCRIPT" >/dev/null
+  env "${envs[@]}" bash "$REPO_ROOT/$CLOSURE_SCRIPT" --incident-id inc-001 >/dev/null
+  after="$(snapshot_runtime_tree "$fixture_root")"
+  [[ "$before" == "$after" ]]
+
+  report_path="$(env "${envs[@]}" bash "$REPO_ROOT/$SNAPSHOT_SCRIPT")"
+  [[ -f "$report_path" ]]
+  grep -q "Orchestration Summary" "$report_path"
+  after="$(snapshot_runtime_tree "$fixture_root")"
+  [[ "$before" == "$after" ]]
+}
+
+assert_success "operator wrappers resolve lineage and surface summaries" case_lookup_and_summary_commands
+assert_success "run health and incident closure readiness wrappers report expected states" case_run_health_and_closure_readiness
+assert_success "operator wrappers remain read-only while ops snapshot writes only the subordinate report" case_wrappers_are_read_only_and_snapshot_writes_report
+
+if (( fail_count > 0 )); then
+  echo "FAILURES: $fail_count" >&2
+  exit 1
+fi
+
+echo "PASS: $pass_count"

--- a/.harmony/orchestration/runtime/workflows/audit/audit-design-package/README.md
+++ b/.harmony/orchestration/runtime/workflows/audit/audit-design-package/README.md
@@ -1,6 +1,6 @@
 ---
 name: "audit-design-package"
-description: "Run the architecture validation pipeline for a design package in rigorous or short mode, persist stage reports into a bounded bundle, and verify that file-writing stages changed the package or emitted explicit zero-change receipts."
+description: "Run the architecture validation pipeline for a design package in rigorous or short mode, persist stage reports into a workflow bundle, and verify that file-writing stages changed the package or emitted explicit zero-change receipts."
 steps:
   - id: "configure"
     file: "stages/01-configure.md"
@@ -43,7 +43,7 @@ _Generated README from canonical workflow `audit-design-package`._
 
 ## Purpose
 
-Run the architecture validation pipeline for a design package in rigorous or short mode, persist stage reports into a bounded bundle, and verify that file-writing stages changed the package or emitted explicit zero-change receipts.
+Run the architecture validation pipeline for a design package in rigorous or short mode, persist stage reports into a workflow bundle, and verify that file-writing stages changed the package or emitted explicit zero-change receipts.
 
 ## Target
 
@@ -64,7 +64,7 @@ This README summarizes the canonical workflow unit at `.harmony/orchestration/ru
 - `model` (text, required=false): Optional model override forwarded to codex or claude
 - `prepare_only` (boolean, required=false): Materialize bundle metadata and prompt packets without invoking the executor
 - `summary_root` (folder, required=false), default=`.harmony/output/reports`: Root directory for the top-level summary report
-- `bundle_root` (folder, required=false), default=`.harmony/output/reports/audits`: Root directory for the bounded stage-report bundle
+- `bundle_root` (folder, required=false), default=`.harmony/output/reports/workflows`: Root directory for the workflow stage-report bundle
 
 ## Failure Conditions
 
@@ -75,16 +75,16 @@ This README summarizes the canonical workflow unit at `.harmony/orchestration/ru
 ## Outputs
 
 - `design_package_workflow_summary` -> `../../output/reports/{{date}}-audit-design-package.md`: Top-level workflow summary with selected mode, readiness verdict, changed files, and next steps
-- `design_package_audit_bundle` -> `../../output/reports/audits/{{date}}-{{slug}}/`: Bounded bundle containing stage reports, metadata, validation state, and aggregate package deltas
-- `design_audit_report` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/01-design-package-audit.md`: Stage report produced by the design package audit prompt
-- `design_package_remediation_report` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/02-design-package-remediation.md`: Short-mode remediation report and package delta receipt
-- `design_red_team_report` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/03-design-red-team.md`: Rigorous-mode adversarial report
-- `design_hardening_report` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/04-design-hardening.md`: Rigorous-mode hardening report and package delta receipt
-- `design_integration_report` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/05-design-integration.md`: Rigorous-mode integration report and package delta receipt
-- `implementation_simulation_report` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/06-implementation-simulation.md`: Buildability simulation report
-- `specification_closure_report` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/07-specification-closure.md`: Specification-closure report or explicit no-op receipt
-- `implementation_architecture_blueprint` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/08-minimal-implementation-architecture-blueprint.md`: Minimal implementer blueprint extracted from the stabilized package
-- `first_implementation_plan` -> `../../output/reports/audits/{{date}}-{{slug}}/reports/09-first-implementation-plan.md`: First production implementation plan derived from the blueprint
+- `design_package_workflow_bundle` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/`: Workflow bundle containing stage reports, metadata, validation state, and aggregate package deltas
+- `design_audit_report` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/01-design-package-audit.md`: Stage report produced by the design package audit prompt
+- `design_package_remediation_report` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/02-design-package-remediation.md`: Short-mode remediation report and package delta receipt
+- `design_red_team_report` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/03-design-red-team.md`: Rigorous-mode adversarial report
+- `design_hardening_report` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/04-design-hardening.md`: Rigorous-mode hardening report and package delta receipt
+- `design_integration_report` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/05-design-integration.md`: Rigorous-mode integration report and package delta receipt
+- `implementation_simulation_report` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/06-implementation-simulation.md`: Buildability simulation report
+- `specification_closure_report` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/07-specification-closure.md`: Specification-closure report or explicit no-op receipt
+- `implementation_architecture_blueprint` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/08-minimal-implementation-architecture-blueprint.md`: Minimal implementer blueprint extracted from the stabilized package
+- `first_implementation_plan` -> `../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/09-first-implementation-plan.md`: First production implementation plan derived from the blueprint
 
 ## Steps
 
@@ -101,7 +101,7 @@ This README summarizes the canonical workflow unit at `.harmony/orchestration/ru
 ## Verification Gate
 
 - [ ] Selected mode is recorded and stage coverage matches it
-- [ ] Every selected stage has a persisted report in the bounded bundle
+- [ ] Every selected stage has a persisted report in the workflow bundle
 - [ ] Every file-writing stage has a change manifest or zero-change receipt
 - [ ] `package-delta.md`, `bundle.yml`, and `validation.md` exist
 - [ ] Top-level summary exists at `.harmony/output/reports/YYYY-MM-DD-audit-design-package.md`

--- a/.harmony/orchestration/runtime/workflows/audit/audit-design-package/stages/01-configure.md
+++ b/.harmony/orchestration/runtime/workflows/audit/audit-design-package/stages/01-configure.md
@@ -12,7 +12,7 @@ description: Resolve target package, mode, bundle paths, and expected stage set.
 - `mode` (optional, default `rigorous`)
 - `output_slug` (optional)
 - `summary_root` (optional, default `.harmony/output/reports`)
-- `bundle_root` (optional, default `.harmony/output/reports/audits`)
+- `bundle_root` (optional, default `.harmony/output/reports/workflows`)
 
 ## Purpose
 

--- a/.harmony/orchestration/runtime/workflows/audit/audit-design-package/stages/08-report.md
+++ b/.harmony/orchestration/runtime/workflows/audit/audit-design-package/stages/08-report.md
@@ -35,7 +35,7 @@ bounded verification.
    - selected mode
    - key blockers or readiness verdict
    - changed files
-   - bounded bundle path
+   - workflow bundle path
 
 ## Output
 

--- a/.harmony/orchestration/runtime/workflows/audit/audit-design-package/workflow.yml
+++ b/.harmony/orchestration/runtime/workflows/audit/audit-design-package/workflow.yml
@@ -1,6 +1,6 @@
 schema_version: "workflow-contract-v1"
 name: "audit-design-package"
-description: "Run the architecture validation pipeline for a design package in rigorous or short mode, persist stage reports into a bounded bundle, and verify that file-writing stages changed the package or emitted explicit zero-change receipts."
+description: "Run the architecture validation pipeline for a design package in rigorous or short mode, persist stage reports into a workflow bundle, and verify that file-writing stages changed the package or emitted explicit zero-change receipts."
 version: "1.0.0"
 entry_mode: "human"
 execution_profile: "core"
@@ -54,8 +54,8 @@ inputs:
   - name: bundle_root
     type: folder
     required: false
-    default: ".harmony/output/reports/audits"
-    description: "Root directory for the bounded stage-report bundle"
+    default: ".harmony/output/reports/workflows"
+    description: "Root directory for the workflow stage-report bundle"
 stages:
   - id: "configure"
     asset: "stages/01-configure.md"
@@ -118,62 +118,62 @@ artifacts:
     format: markdown
     determinism: unique
     description: "Top-level workflow summary with selected mode, readiness verdict, changed files, and next steps"
-  - name: design_package_audit_bundle
-    path: "../../output/reports/audits/{{date}}-{{slug}}/"
+  - name: design_package_workflow_bundle
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/"
     kind: directory
     format: mixed
     determinism: unique
-    description: "Bounded bundle containing stage reports, metadata, validation state, and aggregate package deltas"
+    description: "Workflow bundle containing stage reports, metadata, validation state, and aggregate package deltas"
   - name: design_audit_report
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/01-design-package-audit.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/01-design-package-audit.md"
     kind: file
     format: markdown
     determinism: unique
     description: "Stage report produced by the design package audit prompt"
   - name: design_package_remediation_report
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/02-design-package-remediation.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/02-design-package-remediation.md"
     kind: file
     format: markdown
     determinism: unique
     description: "Short-mode remediation report and package delta receipt"
   - name: design_red_team_report
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/03-design-red-team.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/03-design-red-team.md"
     kind: file
     format: markdown
     determinism: unique
     description: "Rigorous-mode adversarial report"
   - name: design_hardening_report
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/04-design-hardening.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/04-design-hardening.md"
     kind: file
     format: markdown
     determinism: unique
     description: "Rigorous-mode hardening report and package delta receipt"
   - name: design_integration_report
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/05-design-integration.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/05-design-integration.md"
     kind: file
     format: markdown
     determinism: unique
     description: "Rigorous-mode integration report and package delta receipt"
   - name: implementation_simulation_report
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/06-implementation-simulation.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/06-implementation-simulation.md"
     kind: file
     format: markdown
     determinism: unique
     description: "Buildability simulation report"
   - name: specification_closure_report
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/07-specification-closure.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/07-specification-closure.md"
     kind: file
     format: markdown
     determinism: unique
     description: "Specification-closure report or explicit no-op receipt"
   - name: implementation_architecture_blueprint
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/08-minimal-implementation-architecture-blueprint.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/08-minimal-implementation-architecture-blueprint.md"
     kind: file
     format: markdown
     determinism: unique
     description: "Minimal implementer blueprint extracted from the stabilized package"
   - name: first_implementation_plan
-    path: "../../output/reports/audits/{{date}}-{{slug}}/reports/09-first-implementation-plan.md"
+    path: "../../output/reports/workflows/{{date}}-audit-design-package-{{slug}}/reports/09-first-implementation-plan.md"
     kind: file
     format: markdown
     determinism: unique
@@ -181,7 +181,7 @@ artifacts:
 done_gate:
   checks:
     - "Selected mode is recorded and stage coverage matches it"
-    - "Every selected stage has a persisted report in the bounded bundle"
+    - "Every selected stage has a persisted report in the workflow bundle"
     - "Every file-writing stage has a change manifest or zero-change receipt"
     - "`package-delta.md`, `bundle.yml`, and `validation.md` exist"
     - "Top-level summary exists at `.harmony/output/reports/YYYY-MM-DD-audit-design-package.md`"

--- a/.harmony/output/README.md
+++ b/.harmony/output/README.md
@@ -11,7 +11,9 @@ Deliverables produced by skills, workflows, and agent work.
 | `drafts/` | Work-in-progress documents | Context-dependent |
 | `plans/` | Design and implementation plans | `YYYY-MM-DD-{description}.md` |
 | `reports/` | Audit reports and analysis results | `YYYY-MM-DD-{description}.md` |
+| `reports/audits/` | Bounded-audit evidence bundles | `YYYY-MM-DD-{slug}/` |
 | `reports/migrations/` | Migration verification evidence bundles | `YYYY-MM-DD-{slug}/` |
+| `reports/workflows/` | Workflow execution bundles | `YYYY-MM-DD-{slug}/` |
 | `reports/decisions/` | Decision-specific optional evidence bundles | `NNN-{slug}/` |
 
 ## Convention Authority
@@ -24,7 +26,11 @@ Deliverables produced by skills, workflows, and agent work.
 
 - Write deliverables here, not in source directories.
 - Reports use date-prefixed filenames for chronological ordering.
+- Bounded-audit evidence bundles belong under `reports/audits/<YYYY-MM-DD>-<slug>/`.
 - Migration evidence bundles belong under `reports/migrations/<YYYY-MM-DD>-<slug>/`.
+- Workflow execution bundles belong under `reports/workflows/<YYYY-MM-DD>-<slug>/`.
+  They must satisfy the workflow bundle contract in
+  `reports/workflows/README.md`.
 - Decision evidence bundles (when needed) belong under
   `reports/decisions/<NNN>-<slug>/`.
 - Drafts are mutable; reports are typically final.

--- a/.harmony/output/plans/2026-03-10-orchestration-domain-phase9-completion-receipt.md
+++ b/.harmony/output/plans/2026-03-10-orchestration-domain-phase9-completion-receipt.md
@@ -89,6 +89,10 @@ Re-open the `campaigns` decision only if one or more of these become true:
 3. Operators need a deterministic portfolio rollup that cannot be expressed
    cleanly through mission, run, incident, or output-report surfaces.
 
+The standing live decision guide for future re-evaluation now lives at:
+
+- `/.harmony/orchestration/practices/campaign-promotion-criteria.md`
+
 ## Phase 9 Verdict
 
 Phase 9 is complete.

--- a/.harmony/output/plans/2026-03-11-audit-design-package-output-surface-cutover-receipt.md
+++ b/.harmony/output/plans/2026-03-11-audit-design-package-output-surface-cutover-receipt.md
@@ -1,0 +1,53 @@
+# Audit Design Package Output Surface Cutover Receipt
+
+## Profile Selection Receipt
+
+- `change_profile`: `atomic`
+- `release_state`: `pre-1.0`
+- `rationale`:
+  - `audit-design-package` workflow-stage bundles were being written under `/.harmony/output/reports/audits/`, which is reserved for bounded-audit evidence bundles.
+  - No external API or cross-repo coordination is involved.
+  - No data migration or backfill is required because the failing `...pipeline-smoke*` directories are non-authoritative local shells.
+- `profile_facts`:
+  - `downtime_tolerance`: not applicable
+  - `external_consumer_coordination`: none required
+  - `data_migration_backfill`: none
+  - `rollback_mechanism`: git revert
+  - `blast_radius`: workflow contract, runner, tests, and output-surface docs
+  - `compliance_constraints`: keep bounded-audit evidence isolated to `reports/audits/`
+
+## Implementation Plan
+
+1. Move `audit-design-package` workflow bundle output from `reports/audits/` to `reports/workflows/`.
+2. Update workflow contract and human-readable workflow docs to match the new sink.
+3. Document the `reports/workflows/` surface and require its README in harness structure validation.
+4. Extend tests so the runner asserts the new output root and the harness/ audit validators continue to pass.
+
+## Impact Map (code, tests, docs, contracts)
+
+- `code`:
+  - `/.harmony/engine/runtime/crates/kernel/src/workflow.rs`
+  - `/.harmony/assurance/runtime/_ops/scripts/validate-harness-structure.sh`
+- `tests`:
+  - `/.harmony/assurance/runtime/_ops/tests/test-design-package-workflow-runner.sh`
+  - `/.harmony/assurance/runtime/_ops/tests/test-validate-audit-convergence-contract.sh`
+  - `/.github/workflows/harness-self-containment.yml`
+- `docs`:
+  - `/.harmony/output/README.md`
+  - `/.harmony/output/reports/workflows/README.md`
+  - `/.harmony/orchestration/runtime/workflows/audit/audit-design-package/README.md`
+  - `/.harmony/orchestration/runtime/workflows/audit/audit-design-package/stages/01-configure.md`
+  - `/.harmony/orchestration/runtime/workflows/audit/audit-design-package/stages/08-report.md`
+- `contracts`:
+  - `/.harmony/orchestration/runtime/workflows/audit/audit-design-package/workflow.yml`
+
+## Compliance Receipt
+
+- `reports/audits/` remains reserved for bounded-audit evidence bundles.
+- `audit-design-package` now uses the workflow execution output surface instead of the bounded-audit surface.
+- Harness validation continues to fail closed for authoritative bounded-audit bundles and now also requires workflow output-surface documentation.
+
+## Exceptions/Escalations
+
+- No exception requested.
+- Follow-up remains available if Harmony wants a stricter first-class contract validator for `reports/workflows/` bundles beyond README-level documentation.

--- a/.harmony/output/plans/2026-03-11-campaign-promotion-documentation-receipt.md
+++ b/.harmony/output/plans/2026-03-11-campaign-promotion-documentation-receipt.md
@@ -1,0 +1,53 @@
+# Campaign Promotion Documentation Receipt
+
+## Profile Selection Receipt
+
+- `change_profile`: `atomic`
+- `release_state`: `pre-1.0`
+- `rationale`:
+  - The repository already had an evidence-backed `no-go` decision for
+    `campaigns`, but it lived mainly in a phase receipt rather than a standing
+    live practice doc.
+  - This change promotes that guidance into the orchestration practices surface
+    without changing runtime behavior.
+- `profile_facts`:
+  - `downtime_tolerance`: not applicable
+  - `external_consumer_coordination`: none required
+  - `data_migration_backfill`: none
+  - `rollback_mechanism`: git revert
+  - `blast_radius`: documentation and future decision hygiene only
+  - `compliance_constraints`: keep `campaigns` optional and aggregation-only
+
+## Implementation Plan
+
+1. Create a standing orchestration practice doc that explains when `campaigns`
+   should stay deferred and when to reopen the decision.
+2. Link that doc from orchestration practices and the implementation agreement.
+3. Update the old Phase 9 receipt so future readers are routed to the live
+   standing guide.
+
+## Impact Map (code, tests, docs, contracts)
+
+- `code`:
+  - none
+- `tests`:
+  - none
+- `docs`:
+  - `/.harmony/orchestration/practices/campaign-promotion-criteria.md`
+  - `/.harmony/orchestration/practices/README.md`
+  - `/.harmony/orchestration/practices/orchestration-domain-implementation-agreement.md`
+  - `/.harmony/output/plans/2026-03-10-orchestration-domain-phase9-completion-receipt.md`
+- `contracts`:
+  - none; this is a live-practice clarification layered on top of existing
+    package contracts
+
+## Compliance Receipt
+
+- `campaigns` remain deferred by default.
+- Future promotion must remain evidence-backed.
+- The standing guidance now lives in the orchestration practices surface rather
+  than only in a historical phase receipt.
+
+## Exceptions/Escalations
+
+- No exception requested.

--- a/.harmony/output/plans/2026-03-11-orchestration-operator-docs-receipt.md
+++ b/.harmony/output/plans/2026-03-11-orchestration-operator-docs-receipt.md
@@ -1,0 +1,53 @@
+# Orchestration Operator Docs Receipt
+
+## Profile Selection Receipt
+
+- `change_profile`: `atomic`
+- `release_state`: `pre-1.0`
+- `rationale`:
+  - operator-hardening guidance needed a live practices surface before the new
+    tooling lands
+  - this change adds no runtime behavior and does not alter authority
+- `profile_facts`:
+  - `downtime_tolerance`: not applicable
+  - `external_consumer_coordination`: none required
+  - `data_migration_backfill`: none
+  - `rollback_mechanism`: git revert
+  - `blast_radius`: practices and runbook guidance only
+  - `compliance_constraints`: preserve runtime/governance authority and
+    fail-closed incident closure
+
+## Implementation Plan
+
+1. Add a standing operator lookup and triage guide.
+2. Add scenario-specific orchestration failure playbooks.
+3. Update orchestration practices discovery so the new docs are easy to find.
+4. Update incident and runbook guidance to require closure-readiness checks in
+   the operator flow.
+
+## Impact Map (code, tests, docs, contracts)
+
+- `code`:
+  - none
+- `tests`:
+  - none
+- `docs`:
+  - `/.harmony/orchestration/practices/operator-lookup-and-triage.md`
+  - `/.harmony/orchestration/practices/orchestration-failure-playbooks.md`
+  - `/.harmony/orchestration/practices/README.md`
+  - `/.harmony/orchestration/practices/incident-lifecycle-standards.md`
+  - `/.harmony/orchestration/governance/production-incident-runbook.md`
+- `contracts`:
+  - none; this is operator guidance layered on top of existing governance and
+    runtime authority
+
+## Compliance Receipt
+
+- operator guidance now routes future users to the lookup and playbook docs
+- incident lifecycle guidance now explicitly requires the closure-readiness tool
+- production runbook now references orchestration-specific lookup and closure
+  commands without altering closure authority
+
+## Exceptions/Escalations
+
+- No exception requested.

--- a/.harmony/output/plans/2026-03-11-orchestration-operator-hardening-plan.md
+++ b/.harmony/output/plans/2026-03-11-orchestration-operator-hardening-plan.md
@@ -1,0 +1,207 @@
+# Plan: Orchestration Operator Hardening
+
+- Audience: engineers improving orchestration operator UX, status visibility,
+  dashboards, and incident/playbook ergonomics
+- Goal: make the live orchestration domain easier to operate under stress
+  without changing its authority model
+- Scope: operator-facing lookup paths, subordinate status projections, incident
+  closure ergonomics, and scenario-specific playbook guidance
+
+## Profile Selection Receipt
+
+- `change_profile`: `atomic`
+- `release_state`: `pre-1.0`
+- `selection_mode`: `auto`
+- `profile_facts`:
+  - `downtime_tolerance`: not applicable for the planning artifact itself; the
+    intended hardening work is additive and should not require runtime cutover
+  - `external_consumer_coordination_ability`: no external consumers are visible;
+    operator surfaces are internal Harmony concerns
+  - `data_migration_backfill_needs`: none required if projections remain
+    subordinate and read from existing canonical surfaces
+  - `rollback_mechanism`: revert new projection scripts, docs, and validators;
+    canonical runtime and governance artifacts remain unchanged
+  - `blast_radius_and_uncertainty`: moderate; touches operator workflows,
+    runtime projections, practices, and validation but should not alter core
+    execution semantics
+  - `compliance_policy_constraints`: dashboards and operator UX must remain
+    subordinate to runtime/governance authority; incident closure must stay
+    fail-closed
+- `hard_gate_evaluation`:
+  - `zero_downtime_requirement_prevents_one_step_cutover`: `false`
+  - `external_consumers_cannot_migrate_in_one_coordinated_release`: `false`
+  - `live_migration_backfill_requires_temporary_coexistence`: `false`
+  - `operational_risk_requires_progressive_exposure_and_staged_validation`: `false`
+- `rationale`: this hardening work is additive and should preserve the current
+  authority split. It can be implemented in one coordinated effort as long as
+  projections remain read-only and validators fail closed.
+
+## Implementation Plan
+
+### Operating Rules
+
+1. Do not create new execution authority while improving operator experience.
+2. Treat dashboards, summaries, indexes, and helper commands as subordinate
+   projections only.
+3. Preserve the current authority split:
+   - runtime state in `/.harmony/orchestration/runtime/`
+   - governance in `/.harmony/orchestration/governance/`
+   - operating guidance in `/.harmony/orchestration/practices/`
+   - durable evidence in `/.harmony/continuity/`
+4. Every new operator view must be reachable from existing canonical
+   identifiers such as `decision_id`, `run_id`, `incident_id`, `queue_item_id`,
+   and `event_id`.
+5. Incident ergonomics may improve, but closure authority and evidence
+   requirements remain governed by `governance/incidents.md`.
+
+### Primary Authorities
+
+Engineers should use these sources first:
+
+1. `/.design-packages/orchestration-domain-design-package/normative/assurance/observability.md`
+2. `/.design-packages/orchestration-domain-design-package/normative/assurance/operator-and-authoring-runbook.md`
+3. `/.harmony/orchestration/governance/incidents.md`
+4. `/.harmony/orchestration/governance/production-incident-runbook.md`
+5. `/.harmony/orchestration/practices/incident-lifecycle-standards.md`
+6. `/.harmony/orchestration/practices/queue-operations-standards.md`
+7. `/.harmony/orchestration/practices/watcher-operations.md`
+8. `/.harmony/orchestration/practices/automation-operations.md`
+9. `/.harmony/orchestration/practices/run-linkage-standards.md`
+
+### Target Outcomes
+
+By the end of this work, operators should be able to:
+
+1. answer the package’s core observability questions without manual grep across
+   unrelated surfaces
+2. inspect watcher, queue, automation, run, mission, and incident health from
+   stable subordinate views
+3. determine incident closure readiness mechanically
+4. follow concrete response playbooks for the most common orchestration failure
+   modes
+
+### Workstreams
+
+| Workstream | Purpose | Expected surfaces |
+| --- | --- | --- |
+| `WS1 Operator Lookups` | add direct lineage lookup and state inspection flows | `runtime/_ops/scripts/`, `practices/` |
+| `WS2 Status Views` | add subordinate rollups for watchers, queue, automations, runs, missions, and incidents | `runtime/_ops/scripts/`, `output/reports/` |
+| `WS3 Incident Ergonomics` | make open/manage/close flows easier and more deterministic | `runtime/incidents/`, `practices/`, `governance/` |
+| `WS4 Playbooks And Validation` | encode scenario-specific response guidance and fail-closed checks | `practices/`, `_ops/scripts/`, assurance validators |
+
+### Recommended Delivery Order
+
+#### Slice 1: Operator Lookup Spine
+
+Build:
+
+- a lineage lookup helper for `decision_id`, `run_id`, `incident_id`,
+  `queue_item_id`, and `event_id`
+- a compact operator practice doc that explains lookup order and expected next
+  artifact hops
+
+Acceptance criteria:
+
+- lookup by canonical id reaches the next relevant artifact without cross-tree
+  manual search
+- lookup output is projection-only and cites canonical source artifacts
+
+#### Slice 2: Status Rollups
+
+Build:
+
+- generated status summaries for `watchers`, `queue`, `automations`, `runs`,
+  `missions`, and `incidents`
+- one operator-facing “ops snapshot” report or command that consolidates the
+  package’s minimum surface visibility table
+
+Acceptance criteria:
+
+- rollups expose the minimum visibility fields named in the package
+- rollups do not become authoritative state
+- stale or missing linkage is surfaced explicitly, not hidden
+
+#### Slice 3: Incident Closure Ergonomics
+
+Build:
+
+- an incident closure-readiness checker
+- a more explicit incident evidence checklist
+- operator guidance for linking runs, decisions, waivers, and follow-up mission
+  state
+
+Acceptance criteria:
+
+- incident closure can be evaluated mechanically before a human closes it
+- missing evidence is visible on the incident path itself
+- follow-up work larger than one bounded response is routed into mission state
+
+#### Slice 4: Scenario-Specific Playbooks
+
+Build playbooks for at least these cases:
+
+1. watcher source unreadable
+2. automation target workflow unresolved
+3. queue item expired without ack
+4. stale queue acknowledgement with wrong `claim_token`
+5. active run missing acknowledgement or heartbeat
+6. incident closure blocked by missing evidence
+
+Acceptance criteria:
+
+- each playbook references the governing policy or runtime artifact
+- each playbook states the first reversible action, the evidence to inspect,
+  and the escalation point
+- playbooks do not authorize policy exceptions on their own
+
+## Concrete Backlog
+
+| ID | Item | Authority | Expected outputs |
+| --- | --- | --- | --- |
+| `OPR-001` | Define the operator lookup matrix for canonical ids and next-hop lineage. | `observability.md`, `operator-and-authoring-runbook.md` | lookup practice doc; acceptance checklist |
+| `OPR-002` | Add a lineage inspection script for `decision_id`, `run_id`, `incident_id`, `queue_item_id`, and `event_id`. | `observability.md` | `runtime/_ops/scripts/lookup-orchestration-lineage.*` |
+| `OPR-003` | Add a run health inspection helper that surfaces evidence-link and decision-link health. | `observability.md`, `run-linkage-standards.md` | `runtime/_ops/scripts/inspect-run-health.*` |
+| `OPR-004` | Add a queue health summary that exposes lane counts, oldest pending age, expired leases, and dead-letter counts. | `observability.md`, `queue-operations-standards.md` | queue summary script/report |
+| `OPR-005` | Add a watcher health summary exposing status, last evaluation, last emitted event, suppression count, and error reason. | `observability.md`, `watcher-operations.md` | watcher summary script/report |
+| `OPR-006` | Add an automation health summary exposing launch attempts, last success, suppression count, and pause/error reason. | `observability.md`, `automation-operations.md` | automation summary script/report |
+| `OPR-007` | Add an incident status and closure-readiness summary exposing owner, severity, linked runs, and missing evidence. | `observability.md`, `incidents.md`, `incident-lifecycle-standards.md` | incident summary script/report |
+| `OPR-008` | Add a consolidated ops snapshot command or report spanning the minimum visibility table. | `observability.md` | top-level operator snapshot |
+| `OPR-009` | Add a fail-closed closure-readiness checker for runtime incidents. | `incidents.md`, `incident-lifecycle-standards.md` | `runtime/_ops/scripts/check-incident-closure-readiness.*` |
+| `OPR-010` | Tighten incident authoring guidance so closure evidence, waivers, and linked runs are explicit. | `incidents.md`, `incident-lifecycle-standards.md` | updated incident practice docs |
+| `OPR-011` | Author playbook guidance for watcher source failures. | `watcher-operations.md`, `operator-and-authoring-runbook.md` | playbook doc |
+| `OPR-012` | Author playbook guidance for queue expiry and stale-ack failures. | `queue-operations-standards.md`, `operator-and-authoring-runbook.md` | playbook doc |
+| `OPR-013` | Author playbook guidance for automation-target resolution failures. | `automation-operations.md`, `automation-policy.md` | playbook doc |
+| `OPR-014` | Author playbook guidance for run liveness and heartbeat-expiry failures. | `run-liveness-and-recovery-spec.md`, `observability.md` | playbook doc |
+| `OPR-015` | Add validators or smoke checks that operator projections remain subordinate and internally resolvable. | `orchestration-domain-implementation-agreement.md`, `observability.md` | assurance checks |
+
+## Impact Map (code, tests, docs, contracts)
+
+- `code`:
+  - expected additions under `/.harmony/orchestration/runtime/_ops/scripts/`
+  - possible subordinate report generators under `/.harmony/orchestration/runtime/`
+- `tests`:
+  - script-level smoke tests for lookup helpers and closure-readiness logic
+  - harness validation hooks for projection integrity
+- `docs`:
+  - new operator lookup and playbook docs under
+    `/.harmony/orchestration/practices/`
+  - possible runbook refinements under `/.harmony/orchestration/governance/`
+- `contracts`:
+  - no new execution authority contracts should be introduced by default
+  - if a new projection contract is needed, it must remain explicitly
+    subordinate to runtime/governance authority
+
+## Compliance Receipt
+
+- This plan keeps operator UX and dashboards subordinate to canonical runtime
+  and governance artifacts.
+- It preserves the package’s observability and lookup requirements.
+- It preserves incident closure as a human-governed, evidence-backed action.
+- It does not propose `campaigns`, new execution containers, or mutable
+  dashboard authority.
+
+## Exceptions/Escalations
+
+- No exception requested for the planning artifact.
+- Reassess before implementation if a proposed dashboard or operator surface
+  starts carrying mutable state or becomes an attempted source of truth.

--- a/.harmony/output/plans/2026-03-11-workflow-bundle-contract-hardening-receipt.md
+++ b/.harmony/output/plans/2026-03-11-workflow-bundle-contract-hardening-receipt.md
@@ -1,0 +1,59 @@
+# Workflow Bundle Contract Hardening Receipt
+
+## Profile Selection Receipt
+
+- `change_profile`: `atomic`
+- `release_state`: `pre-1.0`
+- `rationale`:
+  - `reports/workflows/` needed a minimum internal contract so workflow bundles remain self-describing as Harmony expands.
+  - No external API migration or dual-write period is required.
+  - Existing bounded-audit isolation must remain intact.
+- `profile_facts`:
+  - `downtime_tolerance`: not applicable
+  - `external_consumer_coordination`: none required
+  - `data_migration_backfill`: none
+  - `rollback_mechanism`: git revert
+  - `blast_radius`: internal workflow runners, output docs, harness validation, and kernel tests
+  - `compliance_constraints`: bounded-audit evidence remains exclusive to `reports/audits/`
+
+## Implementation Plan
+
+1. Define a minimum workflow execution bundle contract for `reports/workflows/`.
+2. Update generic workflow runs and `audit-design-package` bundles to emit the contract.
+3. Enforce the contract in harness structure validation for authoritative workflow bundles.
+4. Add tests that verify the contract files and bundle root for both generic and specialized workflow runners.
+
+## Impact Map (code, tests, docs, contracts)
+
+- `code`:
+  - `/.harmony/engine/runtime/crates/kernel/src/pipeline.rs`
+  - `/.harmony/engine/runtime/crates/kernel/src/workflow.rs`
+  - `/.harmony/assurance/runtime/_ops/scripts/validate-harness-structure.sh`
+- `tests`:
+  - `/.harmony/engine/runtime/crates/kernel/src/pipeline.rs`
+  - `/.harmony/engine/runtime/crates/kernel/src/workflow.rs`
+  - `/.harmony/assurance/runtime/_ops/tests/test-design-package-workflow-runner.sh`
+- `docs`:
+  - `/.harmony/output/README.md`
+  - `/.harmony/output/reports/workflows/README.md`
+- `contracts`:
+  - `workflow-execution-bundle` contract for `/.harmony/output/reports/workflows/<YYYY-MM-DD>-<slug>/`
+
+## Compliance Receipt
+
+- Authoritative workflow bundles now require:
+  - `bundle.yml`
+  - `summary.md`
+  - `commands.md`
+  - `validation.md`
+  - `inventory.md`
+  - `reports/`
+  - `stage-inputs/`
+  - `stage-logs/`
+- `bundle.yml` now carries the minimum workflow-bundle metadata pointers and directory identifiers.
+- Harness validation enforces the workflow-bundle contract only for authoritative bundles and continues to ignore empty local workspace shells.
+
+## Exceptions/Escalations
+
+- No exception requested.
+- The stale local `/.harmony/output/reports/pipelines/` shell was removed after the contract cutover so only the canonical `reports/workflows/` surface remains for new workflow bundles.

--- a/.harmony/output/reports/workflows/README.md
+++ b/.harmony/output/reports/workflows/README.md
@@ -1,0 +1,32 @@
+# Workflow Reports
+
+Workflow execution bundles live here.
+
+## Contract
+
+- Workflow run bundles use date-prefixed directories:
+  - `YYYY-MM-DD-<slug>/`
+- Workflow bundles are not bounded-audit evidence bundles.
+- Bounded audits remain under:
+  - `/.harmony/output/reports/audits/`
+- Each authoritative workflow bundle must include:
+  - `bundle.yml`
+  - `summary.md`
+  - `commands.md`
+  - `validation.md`
+  - `inventory.md`
+  - `reports/`
+  - `stage-inputs/`
+  - `stage-logs/`
+- `bundle.yml` must declare:
+  - `kind: workflow-execution-bundle`
+  - `id: <bundle-directory-name>`
+  - `summary: summary.md`
+  - `commands: commands.md`
+  - `validation: validation.md`
+  - `inventory: inventory.md`
+  - `reports_dir: reports`
+  - `stage_inputs_dir: stage-inputs`
+  - `stage_logs_dir: stage-logs`
+- Workflow bundles may include additional workflow-specific files alongside the
+  minimum contract files.


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Implements the orchestration operator-hardening surface across the runtime,
CLI, shell wrappers, and `harmony_studio`, and closes the related hygiene
and documentation gaps around workflow bundles, campaign deferment guidance,
and output-surface contracts.

## Why

No-Issue: close out the comprehensive orchestration-domain rollout with the
remaining operator-facing and repo-hygiene work in one reviewable branch.

This gives Harmony a real read-only operator layer for lineage lookup,
surface health inspection, closure-readiness checks, and Studio-based
operations views without introducing new execution authority.

## How

Added a shared read-only orchestration inspection layer in
`harmony_core::orchestration`, exposed it through new `harmony
orchestration ...` CLI commands plus thin `_ops/scripts` wrappers, and
integrated the same data path into a new Operations workspace in
`harmony_studio`.

Also corrected the `audit-design-package` workflow bundle placement from the
audit namespace into `reports/workflows`, hardened workflow-bundle
contracts/validation, documented campaign-promotion criteria as a standing
orchestration practice, and cleaned up the stale local `reports/pipelines/`
shell.

## Profile Selection Receipt

- Semantic version source(s): `version.txt` and `.release-please-manifest.json`
  (`0.4.9`)
- Release state (`pre-1.0` or `stable`): `pre-1.0`
- `change_profile` (`atomic` or `transitional`): `atomic`
- Hard-gate facts (downtime, coordination, migration/backfill, rollback,
  blast radius, compliance): no downtime requirement; no external consumer
  coordination; no data migration/backfill; rollback is git revert; blast
  radius is bounded to orchestration runtime/governance/practices, engine
  runtime crates, output-surface contracts, and Studio; compliance requires
  bounded-audit isolation, subordinate operator projections, and fail-closed
  incident closure
- Tie-break status: `none`
- `transitional_exception_note` (required when `pre-1.0` +
  `transitional`): `n/a`

## Implementation Plan

- Workstreams and scope:
  - shared orchestration inspection layer in runtime Rust code
  - new `harmony orchestration ...` CLI commands and shell wrappers
  - read-only Operations workspace in `harmony_studio`
  - operator lookup/playbook/runbook documentation
  - workflow-bundle contract hardening and audit/workflow output-surface
    cleanup
- Public interfaces/types/contracts affected:
  - `harmony orchestration lookup ...`
  - `harmony orchestration summary --surface ...`
  - `harmony orchestration incident closure-readiness --incident-id <id>`
  - workflow execution bundle contract under
    `/.harmony/output/reports/workflows/`
  - `harmony_studio` Operations workspace
- Test scenarios:
  - lineage lookup by `run_id`, `decision_id`, `queue_item_id`, `event_id`,
    `incident_id`, `automation_id`, `watcher_id`, and `mission_id`
  - watcher/queue/automation/run/mission/incident summary rendering
  - fail-closed incident closure-readiness
  - read-only wrapper behavior plus ops snapshot report generation
  - Studio operations section switching, lookup rendering, and incident
    blocker/playbook rendering
- Assumptions/defaults:
  - `harmony_studio` remains the operator UI host
  - no web UI is introduced in this branch
  - dashboards and helpers remain subordinate projections only

## Impact Map (code, tests, docs, contracts)

- Code:
  - `/.harmony/engine/runtime/crates/core/src/orchestration.rs`
  - `/.harmony/engine/runtime/crates/kernel/src/main.rs`
  - `/.harmony/engine/runtime/crates/kernel/src/orchestration.rs`
  - `/.harmony/engine/runtime/crates/studio/src/app_state.rs`
  - `/.harmony/engine/runtime/crates/studio/src/main.rs`
  - `/.harmony/engine/runtime/crates/studio/ui/app.slint`
  - `/.harmony/orchestration/runtime/_ops/scripts/*.sh`
- Tests:
  - `/.harmony/orchestration/runtime/_ops/tests/test-operator-hardening.sh`
  - `harmony_core` orchestration unit tests
  - `harmony_kernel` CLI parser tests
  - `harmony_studio` operations tests
  - `/.harmony/assurance/runtime/_ops/tests/test-validate-audit-convergence-contract.sh`
- Docs:
  - `/.harmony/orchestration/practices/operator-lookup-and-triage.md`
  - `/.harmony/orchestration/practices/orchestration-failure-playbooks.md`
  - `/.harmony/orchestration/governance/production-incident-runbook.md`
  - `/.harmony/engine/runtime/README.md`
  - `/.harmony/orchestration/runtime/README.md`
  - `/.harmony/capabilities/runtime/commands/studio.md`
  - `/.harmony/START.md`
  - `/.harmony/catalog.md`
- Contracts:
  - workflow execution bundle contract in
    `/.harmony/output/reports/workflows/README.md`
  - bounded-audit authoritative-bundle validation behavior
  - standing campaign defer/promotion guidance in orchestration practices

## Compliance Receipt

- [x] Selected exactly one execution profile before planning/implementation.
- [x] Applied release-maturity gate from semantic version.
- [x] Enforced pre-1.0 default (`atomic`) unless hard gates required
  `transitional`.
- [x] Included `transitional_exception_note` when required.
- [x] Included tie-break escalation when applicable.
- [x] Updated impacted contracts/docs/tests.
- [x] Honored charter change-control constraint (no direct principles charter
  edits without override evidence).

## Exceptions/Escalations

none

## Tradeoffs

- The new Studio Operations workspace is intentionally read-only and text-first;
  it prioritizes correctness and shared logic reuse over a heavier custom UI.
- Operator wrappers currently shell out to the Rust CLI rather than duplicating
  logic, which keeps one inspection path authoritative at the cost of a CLI
  dependency.
- The old local `reports/pipelines/` shell was removed, but no separate legacy
  compatibility shim was added because it was untracked workspace output.

## Testing

- `cargo test --manifest-path .harmony/engine/runtime/crates/Cargo.toml -p harmony_core orchestration::`
- `cargo test --manifest-path .harmony/engine/runtime/crates/Cargo.toml -p harmony_kernel orchestration`
- `cargo test --manifest-path .harmony/engine/runtime/crates/Cargo.toml -p harmony_studio`
- `bash .harmony/orchestration/runtime/_ops/tests/test-operator-hardening.sh`
- `bash .harmony/assurance/runtime/_ops/tests/test-design-package-workflow-runner.sh`
- `bash .harmony/assurance/runtime/_ops/tests/test-validate-audit-convergence-contract.sh`
- `bash .harmony/orchestration/runtime/workflows/_ops/scripts/generate-workflow-guides.sh --workflow-id audit-design-package`
- `bash .harmony/orchestration/runtime/workflows/_ops/scripts/validate-workflows.sh --workflow-id audit-design-package`
- `bash .harmony/orchestration/runtime/_ops/scripts/validate-orchestration-runtime.sh`
- `bash .harmony/assurance/runtime/_ops/scripts/validate-harness-structure.sh`
- `git diff --check`

## Rollout

Internal harness/runtime rollout only. No external flag or migration sequence is
required. The new operator surfaces are additive and read-only.

## Convivial Purpose Check

- [x] Feature expands genuine user capability (not synthetic engagement).
- [x] Attention and interruption behavior are justified and user-controllable.
- [x] No manipulative patterns or dark-pattern mechanics are introduced.
- [x] Data collection/extraction risk is minimal and explicitly justified.

## Risk Rubric

- Risk class: [ ] Trivial [ ] Low [ ] Medium [x] High
- Rollback plan: revert the branch commit(s) to remove the operator layer,
  workflow-bundle contract hardening, and related docs/tests
- Rollback handle: `git revert fac1a8f9`
- Flags changed (name, owner, expiry, rollout): `none`
- Autonomy eligibility: [ ] autonomy:auto-merge [x] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: no formal threat-model doc change; preserved
  read-only operator surfaces and fail-closed incident closure semantics

## Observability and Performance

- Traces/logs/metrics for changed flows: operator layer reads canonical runtime,
  governance, and continuity artifacts; no new production telemetry sink added
- Representative traces for high risk changes: covered by runtime shell smoke
  tests and Studio operations tests
- Performance or bundle impact: minor additional CLI/file-walk cost for
  operator inspection; acceptable for operator-only paths

## License and Provenance

- New dependencies and licenses: no new third-party crates; reused existing
  workspace crates and existing `slint`
- Generated code/templates provenance notes: `audit-design-package` README
  regenerated through the canonical workflow guide generator

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

No screenshots attached. `harmony_studio` gained a read-only Operations
workspace panel for overview, lookup, runs, incidents, queue, watchers,
automations, missions, and playbooks.
