### PR TITLE
docs(proposals): define proposal lifecycle rules

### DIFF
--- a/.harmony/scaffolding/governance/patterns/design-proposal-standard.md
+++ b/.harmony/scaffolding/governance/patterns/design-proposal-standard.md
@@ -54,15 +54,23 @@ Every standard-governed design proposal must contain:
 - `normative/experience/screen-states-and-flows.md`
 - `normative/assurance/implementation-readiness.md`
 
-## Optional Modules
+## Module Set
 
 Allowed `selected_modules` values:
 
-- `contracts`
-- `conformance`
 - `reference`
 - `history`
+- `contracts`
+- `conformance`
 - `canonicalization`
+
+Default module behavior for the canonical `/create-design-proposal` workflow:
+
+- every newly scaffolded design proposal includes `reference` and `history`
+- `domain-runtime` proposals also include `contracts`, `conformance`, and
+  `canonicalization` by default
+- `experience-product` proposals do not include `contracts`, `conformance`, or
+  `canonicalization` unless explicitly requested
 
 Module requirements:
 
@@ -127,6 +135,54 @@ Archived design proposal READMEs must also:
 
 The README may describe proposal-local reading order or precedence, but it must
 not claim enduring repository authority.
+
+## Proposal Lifecycle Rule
+
+Standard-governed design proposals use the generic proposal lifecycle with the
+following design-specific content gates:
+
+1. `draft` means scaffold-complete, not implementation-ready.
+   - The core artifact set exists.
+   - The class-specific required docs exist.
+   - `implementation/minimal-implementation-blueprint.md` and
+     `implementation/first-implementation-plan.md` may still be placeholders.
+   - The proposal is ready for content authoring and audit, not yet for
+     implementation.
+2. `in-review` means content-complete enough for real design review.
+   - The class-specific normative docs contain the spec/PRD-equivalent design
+     content for the package.
+   - The implementation blueprint and first implementation plan reflect the
+     current design rather than scaffold placeholders.
+   - Every selected module contains the supporting material required by that
+     module set.
+3. `accepted` means implementation-ready temporary authority.
+   - The readiness definition below is satisfied.
+   - A competent engineer can implement the first slice without inventing
+     architecture, contracts, runtime behavior, or validation expectations.
+4. `implemented` means promotion-complete and archive-ready.
+   - Durable targets have absorbed every required runtime, documentation,
+     contract, schema, fixture, validator, or operator-guide artifact needed to
+     stand on their own.
+   - Canonical targets no longer depend on the proposal path.
+5. `archived` means historical retention only.
+   - The proposal has moved to the archive path with archive metadata and
+     evidence recorded in `proposal.yml` and `/.proposals/registry.yml`.
+
+Artifact classes in this lifecycle:
+
+- proposal metadata and navigation:
+  `proposal.yml`, `design-proposal.yml`, `README.md`,
+  `navigation/artifact-catalog.md`, `navigation/source-of-truth-map.md`
+- spec/PRD-equivalent design authority:
+  class-specific `normative/` docs plus
+  `implementation/minimal-implementation-blueprint.md` and
+  `implementation/first-implementation-plan.md`
+- default supporting context:
+  `reference/README.md` and `history/README.md`
+- conditional proof and promotion surfaces:
+  `contracts/`, `conformance/`, and
+  `navigation/canonicalization-target-map.md` when selected or required by the
+  target promotion path
 
 ## Readiness Definition
 

--- a/.harmony/scaffolding/governance/patterns/proposal-standard.md
+++ b/.harmony/scaffolding/governance/patterns/proposal-standard.md
@@ -104,6 +104,45 @@ Rules:
   `archive.disposition=implemented`.
 - `lifecycle.temporary` must remain `true`.
 
+## Lifecycle Rule
+
+Proposals move through one active lifecycle and one archive lifecycle:
+
+1. `draft`
+   - The proposal package exists at the active proposal path.
+   - `proposal.yml`, subtype manifest, `README.md`, and navigation files exist.
+   - The registry projection exists under `/.proposals/registry.yml`.
+   - Subtype-specific required files may still be placeholders unless the
+     subtype standard says otherwise.
+2. `in-review`
+   - The proposal content is authored enough for substantive review.
+   - Promotion targets, reading order, and subtype-specific required artifacts
+     are explicit enough to evaluate the proposal without inventing missing
+     artifact classes.
+3. `accepted`
+   - The proposal is approved as the temporary implementation or decision aid
+     to use for promotion work.
+   - Subtype-specific readiness rules for `accepted` status must be satisfied
+     before this status is set.
+4. `implemented` or `rejected`
+   - `implemented` means the proposal's durable outputs have been promoted into
+     the declared `promotion_targets`.
+   - `rejected` means the proposal will not be promoted and is waiting for
+     archival or historical retention handling.
+5. `archived`
+   - The proposal moves to `/.proposals/.archive/<kind>/<proposal_id>/`.
+   - `archive.*` metadata records disposition, origin, and promotion evidence.
+
+Rules:
+
+- Proposals may not claim canonical authority at any lifecycle stage.
+- Subtype standards define what content must exist before a proposal is
+  considered review-ready or acceptance-ready.
+- Promotion into durable authority must happen before archival when
+  `archive.disposition=implemented`.
+- After promotion, canonical targets must stand on their own without
+  dependencies on `/.proposals/` paths.
+
 ## Registry Contract
 
 `/.proposals/registry.yml` must define:


### PR DESCRIPTION
Policy reference: `.harmony/agency/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Add an explicit proposal lifecycle rule to the generic proposal standard and
make the design proposal lifecycle and required artifact classes explicit.
Clarify default module behavior so the governance docs match the current
`/create-design-proposal` scaffold behavior.

## Why

Proposal lifecycle expectations were implicit across the scaffold workflow,
validators, and standards docs. This made it unclear which documents belong in
a design proposal beyond the spec/PRD-equivalent content and when a proposal is
only scaffold-complete versus implementation-ready.

No-Issue: governance docs closeout for proposal lifecycle clarification

## How

Add a generic lifecycle section to the base proposal standard. Add a
design-specific lifecycle section that separates metadata/navigation,
spec-equivalent design authority, default supporting context, and conditional
promotion-proof surfaces.

Also reconcile the reference/history ambiguity by documenting the workflow's
current default module behavior instead of leaving it implicit.

## Profile Selection Receipt

- Semantic version source(s): `version.txt` (`0.4.12`)
- Release state (`pre-1.0` or `stable`): `pre-1.0`
- `change_profile` (`atomic` or `transitional`): `atomic`
- Hard-gate facts (downtime, coordination, migration/backfill, rollback, blast radius, compliance): docs-only governance change; no downtime, no external coordination, no migration/backfill, rollback via revert, low blast radius limited to proposal-governance interpretation, must preserve proposal non-canonical rules and validator alignment
- Tie-break status: none
- `transitional_exception_note` (required when `pre-1.0` + `transitional`): n/a

## Implementation Plan

- Workstreams and scope: update generic proposal lifecycle rules; update design proposal lifecycle/content rules; clarify default module behavior
- Public interfaces/types/contracts affected: proposal governance docs only
- Test scenarios: targeted harness/framing alignment check
- Assumptions/defaults: current scaffold behavior for `reference` and `history` remains authoritative until runtime/template behavior changes

## Impact Map (code, tests, docs, contracts)

- Docs/contracts: `.harmony/scaffolding/governance/patterns/proposal-standard.md`, `.harmony/scaffolding/governance/patterns/design-proposal-standard.md`
- Tests: none added
- Validation: `bash .harmony/assurance/runtime/_ops/scripts/alignment-check.sh --profile harness,framing`

## Compliance Receipt

- [x] Selected exactly one execution profile before planning/implementation.
- [x] Applied release-maturity gate from semantic version.
- [x] Enforced pre-1.0 default (`atomic`) unless hard gates required `transitional`.
- [x] Included `transitional_exception_note` when required.
- [x] Included tie-break escalation when applicable.
- [x] Updated impacted contracts/docs/tests.
- [x] Honored charter change-control constraint (no direct principles charter edits without override evidence).

## Exceptions/Escalations

none

## Tradeoffs

This change documents current behavior rather than changing scaffold or
validator enforcement. If the repo later wants `reference` or `history` to be
truly optional for design proposals, the workflow, templates, and validators
will need a follow-up alignment change.

## Testing

- `bash .harmony/assurance/runtime/_ops/scripts/alignment-check.sh --profile harness,framing`

## Rollout

n/a

## Convivial Purpose Check

- [x] Feature expands genuine user capability (not synthetic engagement).
- [x] Attention and interruption behavior are justified and user-controllable.
- [x] No manipulative patterns or dark-pattern mechanics are introduced.
- [x] Data collection/extraction risk is minimal and explicitly justified.

## Risk Rubric

- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High
- Rollback plan: revert the two standards docs
- Rollback handle: revert commit `6e4c9087`
- Flags changed (name, owner, expiry, rollout): none
- Autonomy eligibility: [x] autonomy:auto-merge [ ] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: n/a

## Observability and Performance

- Traces/logs/metrics for changed flows: n/a
- Representative traces for high risk changes: n/a
- Performance or bundle impact: none

## License and Provenance

- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

No visual changes.
