### PR TITLE
docs(readme): add root octon overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+---
+title: Octon
+description: Root overview for the Octon governed harness repository.
+---
+
+# Octon
+
+Octon is a portable, agent-first engineering harness that turns a repository
+into a governed autonomous engineering environment.
+
+It is not primarily product code. Octon is the operating layer around a
+codebase: it defines how agents bootstrap, what they can do, how work is
+orchestrated, which actions require approval, and what evidence is required
+before work is considered complete.
+
+This repository is self-hosting: Octon is used here to evolve the Octon
+harness itself with safe, reviewable, and verifiable changes.
+
+## Core Model
+
+- Portable harness: designed to be copied into other repositories.
+- System-governed autonomy: contracts, policies, and workflows run by default.
+- Deny-by-default control plane: consequential actions are fail-closed unless
+  authorized.
+- No silent apply: material side effects require explicit promotion and
+  evidence.
+- Continuity and assurance: logs, decisions, validation, and completion gates
+  preserve traceability.
+
+## Repository Layout
+
+Most of the project lives under `.octon/`:
+
+- [`.octon/agency/`](.octon/agency/) for agent personas, delegation, and
+  governance contracts.
+- [`.octon/capabilities/`](.octon/capabilities/) for commands, skills, tools,
+  services, and policy operations.
+- [`.octon/orchestration/`](.octon/orchestration/) for workflows, missions,
+  watchers, and operating standards.
+- [`.octon/cognition/`](.octon/cognition/) for principles, methodology,
+  context, and architecture.
+- [`.octon/continuity/`](.octon/continuity/) for tasks, logs, entities, and
+  decision continuity across sessions.
+- [`.octon/assurance/`](.octon/assurance/) for definition-of-done, validation,
+  and release or completion gates.
+- [`.octon/engine/`](.octon/engine/) for the executable runtime authority.
+- [`.octon/output/`](.octon/output/) for generated reports, plans, and
+  artifacts.
+
+The human-led ideation area in [`.octon/ideation/`](.octon/ideation/) is
+intentionally outside normal autonomous agent work unless explicitly scoped by
+a human.
+
+## Executable Runtime
+
+Octon includes a real runtime, not just governance documents.
+
+The runtime lives under [`.octon/engine/runtime/`](.octon/engine/runtime/) and
+includes:
+
+- launcher entrypoints in `run` and `run.cmd`
+- the shared `octon` CLI
+- the `octon-policy` policy engine
+- a Studio host for visual workflow and operator surfaces
+- Rust workspace crates such as `core`, `wasm_host`, `kernel`, `studio`,
+  `assurance_tools`, and `policy_engine`
+
+## Start Here
+
+If you are new to the repo, start with:
+
+- [`.octon/START.md`](.octon/START.md) for boot sequence and orientation.
+- [`.octon/README.md`](.octon/README.md) for the shared harness overview.
+- [`.octon/OBJECTIVE.md`](.octon/OBJECTIVE.md) for the current workspace goal.
+- [`.octon/engine/runtime/README.md`](.octon/engine/runtime/README.md) for
+  runtime entrypoints and operator surfaces.
+
+## Quick Start
+
+```bash
+.octon/engine/runtime/run --help
+.octon/engine/runtime/run studio
+```


### PR DESCRIPTION
## What

Adds a new root README that explains what Octon is, how the repository is
organized, where the executable runtime lives, and which canonical docs new
readers should open first.

## Why

The repository did not have a root README, which made the top-level purpose
and entry points hard to discover.

No-Issue: requested repo overview README

## How

Summarized the existing canonical `.octon` orientation and runtime docs into
a concise root-level entrypoint, then linked readers to the deeper source of
truth documents instead of duplicating contracts in full.

## Profile Selection Receipt

- Semantic version source(s): `.octon/engine/runtime/crates/Cargo.toml`
- Release state (`pre-1.0` or `stable`): `stable`
- `change_profile` (`atomic` or `transitional`): `atomic`
- Hard-gate facts (downtime, coordination, migration/backfill, rollback, blast radius, compliance): docs-only change; no downtime, no coordination, no migration/backfill, rollback by revert, low blast radius, no special compliance constraint
- Tie-break status: none
- `transitional_exception_note` (required when `pre-1.0` + `transitional`): n/a

## Implementation Plan

- Workstreams and scope: add a single root `README.md` with overview, layout,
  runtime, and start-here sections
- Public interfaces/types/contracts affected: none
- Test scenarios: manual readback against canonical `.octon` docs
- Assumptions/defaults: root README should stay high-level and defer detailed
  contracts to existing docs

## Impact Map (code, tests, docs, contracts)

- Code: none
- Tests: none
- Docs: add root `README.md`
- Contracts: none

## Compliance Receipt

- [x] Selected exactly one execution profile before planning/implementation.
- [x] Applied release-maturity gate from semantic version.
- [x] Enforced pre-1.0 default (`atomic`) unless hard gates required `transitional`.
- [x] Included `transitional_exception_note` when required.
- [x] Included tie-break escalation when applicable.
- [x] Updated impacted contracts/docs/tests.
- [x] Honored charter change-control constraint (no direct principles charter edits without override evidence).

## Exceptions/Escalations

none

## Tradeoffs

The root README intentionally stays concise, so it summarizes Octon and links
into the canonical `.octon` surfaces rather than restating every subsystem
contract.

## Testing

Manual verification only:
- read back the new README for accuracy and doc-structure compliance
- diffed the file against the staged change

No automated tests were run because this is a documentation-only change.

## Rollout

n/a

## Convivial Purpose Check

- [x] Feature expands genuine user capability (not synthetic engagement).
- [x] Attention and interruption behavior are justified and user-controllable.
- [x] No manipulative patterns or dark-pattern mechanics are introduced.
- [x] Data collection/extraction risk is minimal and explicitly justified.

## Risk Rubric

- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High
- Rollback plan: revert the README commit or PR
- Rollback handle: `git revert b01b170e`
- Flags changed (name, owner, expiry, rollout): none
- Autonomy eligibility: [x] autonomy:auto-merge [ ] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: none

## Observability and Performance

- Traces/logs/metrics for changed flows: none
- Representative traces for high risk changes: n/a
- Performance or bundle impact: none

## License and Provenance

- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

None.
