### PR TITLE
docs(readme): tighten root overview copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Editor settings
 .vscode/
 .idea/
+.codex/config.toml
 
 # Temporary files
 tmp/

--- a/README.md
+++ b/README.md
@@ -5,58 +5,42 @@ description: Root overview for the Octon governed harness repository.
 
 # Octon
 
-Octon is a portable, agent-first engineering harness that turns a repository
-into a governed autonomous engineering environment.
+Octon is a portable, agent-first engineering harness that turns a repository into a governed autonomous work environment.
 
-It is not primarily product code. Octon is the operating layer around a
-codebase: it defines how agents bootstrap, what they can do, how work is
-orchestrated, which actions require approval, and what evidence is required
-before work is considered complete.
+It is not "the product code". Octon is the operating layer around a codebase: it defines how agents bootstrap, what they can do, how work is orchestrated, which actions require approval, and what evidence is required before work is considered complete.
 
-This repository is self-hosting: Octon is used here to evolve the Octon
-harness itself with safe, reviewable, and verifiable changes.
+The core idea is: AI can move faster, but only inside a system with explicit contracts, deny-by-default permissions, continuity logs, and assurance gates.
+
+This repository is also self-hosting: Octon is used to evolve itself with safe, reviewable, and verifiable changes.
 
 ## Core Model
 
 - Portable harness: designed to be copied into other repositories.
 - System-governed autonomy: contracts, policies, and workflows run by default.
-- Deny-by-default control plane: consequential actions are fail-closed unless
-  authorized.
-- No silent apply: material side effects require explicit promotion and
-  evidence.
-- Continuity and assurance: logs, decisions, validation, and completion gates
-  preserve traceability.
+- Deny-by-default control plane: consequential actions are fail-closed unless authorized.
+- No silent apply: material side effects require explicit promotion and evidence.
+- Continuity and assurance: logs, decisions, validation, and completion gates preserve traceability.
 
 ## Repository Layout
 
 Most of the project lives under `.octon/`:
 
-- [`.octon/agency/`](.octon/agency/) for agent personas, delegation, and
-  governance contracts.
-- [`.octon/capabilities/`](.octon/capabilities/) for commands, skills, tools,
-  services, and policy operations.
-- [`.octon/orchestration/`](.octon/orchestration/) for workflows, missions,
-  watchers, and operating standards.
-- [`.octon/cognition/`](.octon/cognition/) for principles, methodology,
-  context, and architecture.
-- [`.octon/continuity/`](.octon/continuity/) for tasks, logs, entities, and
-  decision continuity across sessions.
-- [`.octon/assurance/`](.octon/assurance/) for definition-of-done, validation,
-  and release or completion gates.
+- [`.octon/agency/`](.octon/agency/) for agent personas, delegation, and governance contracts.
+- [`.octon/capabilities/`](.octon/capabilities/) for commands, skills, tools, services, and policy operations.
+- [`.octon/orchestration/`](.octon/orchestration/) for workflows, missions, watchers, and operating standards.
+- [`.octon/cognition/`](.octon/cognition/) for principles, methodology, context, and architecture.
+- [`.octon/continuity/`](.octon/continuity/) for tasks, logs, entities, and decision continuity across sessions.
+- [`.octon/assurance/`](.octon/assurance/) for definition-of-done, validation, and release or completion gates.
 - [`.octon/engine/`](.octon/engine/) for the executable runtime authority.
-- [`.octon/output/`](.octon/output/) for generated reports, plans, and
-  artifacts.
+- [`.octon/output/`](.octon/output/) for generated reports, plans, and artifacts.
 
-The human-led ideation area in [`.octon/ideation/`](.octon/ideation/) is
-intentionally outside normal autonomous agent work unless explicitly scoped by
-a human.
+The human-led ideation area in [`.octon/ideation/`](.octon/ideation/) is intentionally outside normal autonomous agent work unless explicitly scoped by a human.
 
 ## Executable Runtime
 
 Octon includes a real runtime, not just governance documents.
 
-The runtime lives under [`.octon/engine/runtime/`](.octon/engine/runtime/) and
-includes:
+The runtime lives under [`.octon/engine/runtime/`](.octon/engine/runtime/) and includes:
 
 - launcher entrypoints in `run` and `run.cmd`
 - the shared `octon` CLI
@@ -72,8 +56,7 @@ If you are new to the repo, start with:
 - [`.octon/START.md`](.octon/START.md) for boot sequence and orientation.
 - [`.octon/README.md`](.octon/README.md) for the shared harness overview.
 - [`.octon/OBJECTIVE.md`](.octon/OBJECTIVE.md) for the current workspace goal.
-- [`.octon/engine/runtime/README.md`](.octon/engine/runtime/README.md) for
-  runtime entrypoints and operator surfaces.
+- [`.octon/engine/runtime/README.md`](.octon/engine/runtime/README.md) for runtime entrypoints and operator surfaces.
 
 ## Quick Start
 


### PR DESCRIPTION
## What

Ignores the local `.codex/config.toml` file and refines the root README copy
to make the repo overview easier to scan.

## Why

The local Codex config should not keep showing up as untracked repo noise, and
the root README wording can be clearer without changing the structure of the
overview.

No-Issue: local ignore cleanup and README wording refinement

## How

Added a targeted ignore rule for `.codex/config.toml` only, then tightened the
existing root README wording while preserving its overall sections and intent.

## Profile Selection Receipt

- Semantic version source(s): `version.txt`
- Release state (`pre-1.0` or `stable`): `pre-1.0`
- `change_profile` (`atomic` or `transitional`): `atomic`
- Hard-gate facts (downtime, coordination, migration/backfill, rollback, blast radius, compliance): docs/config-only change; no downtime, no coordination, no migration/backfill, rollback by revert, low blast radius, no special compliance constraint
- Tie-break status: none
- `transitional_exception_note` (required when `pre-1.0` + `transitional`): n/a

## Implementation Plan

- Workstreams and scope: add one targeted `.gitignore` rule and commit the existing root README wording update
- Public interfaces/types/contracts affected: root README wording only; no runtime or contract surface change
- Test scenarios: inspect git status behavior and review the README diff for accuracy and readability
- Assumptions/defaults: `.codex/config.toml` is local-only and should remain untracked

## Impact Map (code, tests, docs, contracts)

- Code: none
- Tests: none
- Docs: `README.md`
- Contracts: none

## Compliance Receipt

- [x] Selected exactly one execution profile before planning/implementation.
- [x] Applied release-maturity gate from semantic version.
- [x] Enforced pre-1.0 default (`atomic`) unless hard gates required `transitional`.
- [x] Included `transitional_exception_note` when required.
- [x] Included tie-break escalation when applicable.
- [x] Updated impacted contracts/docs/tests.
- [x] Honored charter change-control constraint (no direct principles charter edits without override evidence).

## Exceptions/Escalations

none

## Tradeoffs

The `.gitignore` rule is intentionally narrow to avoid hiding broader `.codex`
content. The README edit focuses on readability rather than expanding scope.

## Testing

Manual verification only:
- confirmed `.codex/config.toml` was untracked and then ignored via the targeted rule
- reviewed the `README.md` diff for wording and structure

No automated tests were run because this change only touches `.gitignore` and
documentation.

## Rollout

n/a

## Convivial Purpose Check

- [x] Feature expands genuine user capability (not synthetic engagement).
- [x] Attention and interruption behavior are justified and user-controllable.
- [x] No manipulative patterns or dark-pattern mechanics are introduced.
- [x] Data collection/extraction risk is minimal and explicitly justified.

## Risk Rubric

- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High
- Rollback plan: revert the two branch commits
- Rollback handle: `git revert 8fb3f9a8 6064b2b8`
- Flags changed (name, owner, expiry, rollout): none
- Autonomy eligibility: [x] autonomy:auto-merge [ ] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: none

## Observability and Performance

- Traces/logs/metrics for changed flows: none
- Representative traces for high risk changes: n/a
- Performance or bundle impact: none

## License and Provenance

- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] All review conversations resolved

## Screenshots / Notes

None.
