### PR TITLE
fix(release): restore refactor-triggered release bumps

### DIFF
--- a/.github/workflows/autonomy-release-health.yml
+++ b/.github/workflows/autonomy-release-health.yml
@@ -224,6 +224,32 @@ jobs:
             fail "Release Please config files are missing from repository."
           fi
 
+          if [[ -f "release-please-config.json" ]]; then
+            release_types="$({
+              jq -r '
+                (
+                  .packages["."]["changelog-sections"]
+                  // ."changelog-sections"
+                  // []
+                )
+                | map(.type)
+                | unique
+                | sort
+                | join(",")
+              ' release-please-config.json 2>/dev/null
+            } || echo "")"
+
+            if [[ -z "${release_types}" ]]; then
+              fail "Release Please changelog sections are missing; releasable commit types are not explicit."
+            elif [[ ",${release_types}," == *",feat,"* ]] \
+              && [[ ",${release_types}," == *",fix,"* ]] \
+              && [[ ",${release_types}," == *",refactor,"* ]]; then
+              pass "Release Please changelog sections keep feat/fix/refactor releasable (${release_types})."
+            else
+              fail "Release Please changelog sections drifted; expected feat, fix, and refactor to be releasable (got: ${release_types})."
+            fi
+          fi
+
           release_please_runs="$({
             gh run list \
               --workflow "Release Please" \

--- a/.octon/framework/engine/practices/release-runbook.md
+++ b/.octon/framework/engine/practices/release-runbook.md
@@ -26,6 +26,8 @@
    - `.github/workflows/release-please.yml`
    - `release-please-config.json`
    - `.release-please-manifest.json`
+   - root-package `changelog-sections` keep `refactor` releasable when
+     structural refactors are expected to cut releases
 
 ## Release
 

--- a/.octon/framework/execution-roles/practices/github-autonomy-runbook.md
+++ b/.octon/framework/execution-roles/practices/github-autonomy-runbook.md
@@ -176,6 +176,8 @@ For Phase C release acceleration:
    `"bump-minor-pre-major": false` and
    `"bump-patch-for-minor-pre-major": true` so non-breaking `0.x` releases
    advance by patch by default.
+5. Structural refactors remain releasable because the root package declares
+   `refactor` in `release-please-config.json` `changelog-sections`.
 
 ---
 
@@ -601,6 +603,9 @@ Phase 5 (provider-agnostic AI gate):
 - Release tags are advancing too quickly while `<1.0.0`:
   verify `release-please-config.json` keeps `"bump-minor-pre-major": false`
   and `"bump-patch-for-minor-pre-major": true`.
+- Refactor merges are no longer opening release PRs:
+  verify `release-please-config.json` keeps `refactor` in the root-package
+  `changelog-sections`.
 - `Autonomy Release Health` fails with
   `AUTONOMY_AUTO_MERGE_ENABLED=false`: set repository variable back to `true`
   unless intentionally paused for incident response.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,24 @@
     ".": {
       "package-name": "octon",
       "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "deps",
+          "section": "Dependencies"
+        },
+        {
+          "type": "refactor",
+          "section": "Refactors"
+        }
+      ],
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
Policy reference: `.octon/framework/execution-roles/practices/pull-request-standards.md`
Reminder: Run `@codex review`.

## What

Restore automatic release PR creation after structural refactors by making
`release-please` treat `refactor` commits as releasable again and by adding a
health check that fails if that config drifts.

## Why

Recent refactor merges were landing on `main` without a follow-on release PR.
The underlying `release-please` run was healthy, but it was classifying plain
`refactor` commits as non-user-facing and skipping them.
No-Issue: release automation regression fix.

## How

Declare explicit root-package `changelog-sections` for `feat`, `fix`, `deps`,
and `refactor` in `release-please-config.json`, then document that contract in
the release runbooks and enforce it in `autonomy-release-health.yml`.

## Profile Selection Receipt

- Semantic version source(s): `version.txt`, `.release-please-manifest.json`, `.octon/octon.yml`
- Release state (`pre-1.0` or `stable`): `pre-1.0`
- `change_profile` (`atomic` or `transitional`): `atomic`
- Hard-gate facts (downtime, coordination, migration/backfill, rollback, blast radius, compliance): no downtime or external coordination; no data migration or backfill; rollback is a single revert; blast radius is limited to release automation, health checks, and release documentation
- Tie-break status: none
- `transitional_exception_note` (required when `pre-1.0` + `transitional`): `n/a`

## Implementation Plan

- Workstreams and scope: update release-please classification, add release-health drift detection, document the contract in release runbooks
- Public interfaces/types/contracts affected: `release-please-config.json`, `Autonomy Release Health`, release runbook guidance
- Test scenarios: config parses; workflow validation passes; health-check logic recognizes `feat`, `fix`, and `refactor` as releasable
- Assumptions/defaults: `main` remains the release branch and refactor merges should continue to cut patch releases while `<1.0.0`

## Impact Map (code, tests, docs, contracts)

- Code: `.github/workflows/autonomy-release-health.yml`
- Tests: workflow-system validation via `.octon/framework/orchestration/runtime/workflows/_ops/scripts/validate-workflows.sh`
- Docs: `.octon/framework/engine/practices/release-runbook.md`, `.octon/framework/execution-roles/practices/github-autonomy-runbook.md`
- Contracts: `release-please-config.json` releasable-commit classification

## Compliance Receipt

- [x] Selected exactly one execution profile before planning/implementation.
- [x] Applied release-maturity gate from semantic version.
- [x] Enforced pre-1.0 default (`atomic`) unless hard gates required `transitional`.
- [x] Included `transitional_exception_note` when required.
- [x] Included tie-break escalation when applicable.
- [x] Updated impacted contracts/docs/tests.
- [x] Honored charter change-control constraint (no direct principles charter edits without override evidence).

## Exceptions/Escalations

none

## Tradeoffs

This makes the releasable commit contract explicit instead of relying on
implicit `release-please` defaults. That is more verbose, but it is far less
fragile.

## Testing

- `jq . release-please-config.json >/dev/null`
- `git diff --check`
- `bash .octon/framework/orchestration/runtime/workflows/_ops/scripts/validate-workflows.sh`

## Rollout

Merge to `main`; the next `Release Please` run on `main` should open the
missing release PR for the queued refactor commits.

## Convivial Purpose Check

- [x] Feature expands genuine user capability (not synthetic engagement).
- [x] Attention and interruption behavior are justified and user-controllable.
- [x] No manipulative patterns or dark-pattern mechanics are introduced.
- [x] Data collection/extraction risk is minimal and explicitly justified.

## Risk Rubric

- Risk class: [ ] Trivial [x] Low [ ] Medium [ ] High
- Rollback plan: revert this PR to restore the prior release-please contract
- Rollback handle: `git revert 9d04a95e8`
- Flags changed (name, owner, expiry, rollout): none
- Autonomy eligibility: [x] autonomy:auto-merge [ ] autonomy:no-automerge

## Contracts and Threat Model

- OpenAPI/JSON-Schema changes: none
- Threat model update/link: not required; no runtime authority widening or new external boundary

## Observability and Performance

- Traces/logs/metrics for changed flows: `Autonomy Release Health` now checks releasable commit-type drift explicitly
- Representative traces for high risk changes: GitHub Actions `Release Please` runs `#261` and `#263` were inspected to confirm the skip path
- Performance or bundle impact: negligible

## License and Provenance

- New dependencies and licenses: none
- Generated code/templates provenance notes: none

## Checklist

- [x] Requirements met; edge cases handled
- [x] Security reviewed (authz, input validation, secrets)
- [x] Tests added or updated
- [x] Observability updated (logs, metrics, traces) if needed
- [x] No speculative abstractions or unnecessary complexity
- [x] Conventions followed; no drift introduced
- [x] Non-obvious decisions documented (comments, ADR)
- [x] Reviewer feedback addressed with fix, commit, push, reply; reviewer-owned threads left for reviewer or maintainer confirmation

## Screenshots / Notes

No UI changes.